### PR TITLE
feat(#16): Pass pinia options via model property

### DIFF
--- a/packages/pinia-orm/src/composables/useDataStore.ts
+++ b/packages/pinia-orm/src/composables/useDataStore.ts
@@ -1,9 +1,13 @@
 import { defineStore } from 'pinia'
 import { useStoreActions } from './useStoreActions'
 
-export function useDataStore(id: string) {
+export function useDataStore(
+  id: string,
+  options: Record<string, any> | null = null
+) {
   return defineStore(id, {
     state: () => ({ data: {} }),
     actions: useStoreActions(),
+    ...options,
   })
 }

--- a/packages/pinia-orm/src/connection/Connection.ts
+++ b/packages/pinia-orm/src/connection/Connection.ts
@@ -37,7 +37,7 @@ export class Connection {
     const newStore =
       typeof this.database.storeGenerator === 'function'
         ? this.database.storeGenerator(this.model.$entity())
-        : useDataStore(this.model.$entity())
+        : useDataStore(this.model.$entity(), this.model.$piniaOptions())
     const store = newStore(this.database.store)
     if (name && typeof store[name] === 'function') {
       store[name](payload)
@@ -52,7 +52,7 @@ export class Connection {
     const newStore =
       typeof this.database.storeGenerator === 'function'
         ? this.database.storeGenerator(this.model.$entity())
-        : useDataStore(this.model.$entity())
+        : useDataStore(this.model.$entity(), this.model.$piniaOptions())
     const store = newStore()
 
     return store.$state.data

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -1,3 +1,4 @@
+import { DefineStoreOptions } from 'pinia'
 import { isNullish, isArray, assert } from '../support/Utils'
 import { Element, Item, Collection } from '../data/Data'
 import { Attribute } from './attributes/Attribute'
@@ -49,6 +50,8 @@ export class Model {
    * property when registering models to the database.
    */
   protected static registries: ModelRegistries = {}
+
+  protected static piniaOptions: any = {}
 
   /**
    * The array of booted models.
@@ -293,6 +296,13 @@ export class Model {
    */
   $entity(): string {
     return this.$self().entity
+  }
+
+  /**
+   * Get the pinia options for this model.
+   */
+  $piniaOptions(): Record<string, any> {
+    return this.$self().piniaOptions
   }
 
   /**

--- a/packages/pinia-orm/tests/feature/repository/save.spec.ts
+++ b/packages/pinia-orm/tests/feature/repository/save.spec.ts
@@ -8,6 +8,7 @@ import {
   assertState,
   fillState,
 } from '../../helpers'
+import { getActivePinia, setActivePinia } from 'pinia'
 
 describe('feature/repository/save', () => {
   class User extends Model {
@@ -16,6 +17,10 @@ describe('feature/repository/save', () => {
     @Num(0) id!: number
     @Str('') name!: string
     @Num(0) age!: number
+
+    static piniaOptions = {
+      persist: true,
+    }
   }
 
   it('does nothing when passing in an empty array', () => {
@@ -26,8 +31,12 @@ describe('feature/repository/save', () => {
     assertState({})
   })
 
-  it('saves a model to the store', () => {
+  it('saves a model to the store and check pinia options', () => {
     const userRepo = useRepo(User)
+    const pinia = getActivePinia()?.use(({ options }) => {
+      expect(options).toHaveProperty('persist', true)
+    })
+    setActivePinia(pinia)
 
     userRepo.save({ id: 1, name: 'John Doe', age: 30 })
 

--- a/packages/pinia-orm/tests/unit/model/Model_pinia_options.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_pinia_options.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+
+import { Model, Attr } from '../../../src'
+
+describe('unit/model/Model', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Attr() id!: number
+
+    static piniaOptions = {
+      persist: true,
+    }
+  }
+
+  it('uses the pinia options in the store', () => {
+    const user = new User({ id: 1, name: 'John Doe' })
+
+    expect(user.$piniaOptions()).toEqual({ persist: true })
+  })
+})


### PR DESCRIPTION
You can now add pinia optionen to the store through the model

````typescript
  class User extends Model {
    static entity = 'users'

    @Num(0) id!: number
    @Str('') name!: string
    @Num(0) age!: number

    static piniaOptions = {
      persist: true,
    }
  }
````

closes #16