### PR TITLE
feat(pinia-orm): add belongsToMany relation function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: 'ci'
 on:
   push:
     branches:
-      - master
+      - '**'
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: 'ci'
 on:
   push:
     branches:
-      - '**'
+      - master
   pull_request:
     branches:
       - master

--- a/docs/content/2.model/3.decorators.md
+++ b/docs/content/2.model/3.decorators.md
@@ -214,9 +214,25 @@ class Cluster extends Model {
 }
 ```
 
+### `@BelongsToMany
+
+Marks a property on the model as a [belongsToMany attribute](../3.relationships/4.many-to-many) type. For example:
+
+```ts
+import { Model, HasManyBy } from 'pinia-orm'
+import Role from '@/models/Role'
+
+class User extends Model {
+  static entity = 'users'
+
+  @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id')
+  roles!: Role[]
+}
+```
+
 ### `@MorphOne`
 
-Marks a property on the model as a [morphOne attribute](../3.relationships/4.polymorphic) type. For example:
+Marks a property on the model as a [morphOne attribute](../3.relationships/5.polymorphic) type. For example:
 
 ```ts
 import { Model, MorphOne } from 'pinia-orm'
@@ -232,7 +248,7 @@ class User extends Model {
 
 ### `@MorphTo`
 
-Marks a property on the model as a [morphTo attribute](../3.relationships/4.polymorphic) type. For example:
+Marks a property on the model as a [morphTo attribute](../3.relationships/5.polymorphic) type. For example:
 
 ```ts
 import { Model, MorphTo } from 'pinia-orm'
@@ -250,5 +266,19 @@ class Image extends Model {
 
   @MorphTo(() => [User, Post], 'imageableId', 'imageableType')
   imageable!: User | Post | null
+}
+```
+
+### `@MorphMany`
+
+Marks a property on the model as a [morphMany attribute](../3.relationships/5.polymorphic) type. For example:
+
+```ts
+import { Model, MorphMany } from 'pinia-orm'
+import Comment from '@/models/Comment'
+class Video extends Model {
+  static entity = 'videos'
+  @MorphMany(() => Comment, 'commentableId', 'commentableType')
+  comments!: Comment[]
 }
 ```

--- a/docs/content/2.model/3.decorators.md
+++ b/docs/content/2.model/3.decorators.md
@@ -214,7 +214,7 @@ class Cluster extends Model {
 }
 ```
 
-### `@BelongsToMany
+### `@BelongsToMany`
 
 Marks a property on the model as a [belongsToMany attribute](../3.relationships/4.many-to-many) type. For example:
 

--- a/docs/content/3.relationships/4.many-to-many.md
+++ b/docs/content/3.relationships/4.many-to-many.md
@@ -1,0 +1,131 @@
+---
+title: Many To Many
+description: ''
+---
+
+Many-to-many relations are slightly more complicated than other relationships. An example of such a relationship is a user with many roles, where the roles are also shared by other users. For example, many users may have the role of "Admin". To define this relationship, three models are needed: User, Role, and RoleUser.
+
+The RoleUser contains the fields to hold id of User and Role model. We'll define `user_id` and `role_id` fields here. The name of RoleUser model could be anything, but for this example, we'll keep it this way to make it easy to understand.
+
+Many-to-many relationships are defined by defining `this.belongsToMany()`.
+
+```js
+class User extends Model {
+  static entity = 'users'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      roles: this.belongsToMany(Role, RoleUser, 'user_id', 'role_id')
+    }
+  }
+}
+
+class Role extends Model {
+  static entity = 'roles'
+
+  static fields () {
+    return {
+      id: this.attr(null)
+    }
+  }
+}
+
+class RoleUser extends Model {
+  static entity = 'roleUser'
+
+  static primaryKey = ['role_id', 'user_id']
+
+  static fields () {
+    return {
+      role_id: this.attr(null),
+      user_id: this.attr(null)
+    }
+  }
+}
+```
+
+The argument order of the `belongsToMany` attribute is:
+
+1. The Related model which is in this case Role.
+2. Intermediate pivot model which is in this case RoleUser.
+3. Field of the pivot model that holds the id value of the parent – User – model.
+4. Field of the pivot model that holds the id value of the related – Role – model.
+
+You may also define custom local key at 5th and 6th argument.
+
+```js
+class User extends Model {
+  static entity = 'users'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      roles: this.belongsToMany(
+        Role,
+        RoleUser,
+        'user_id',
+        'role_id',
+        'user_local_id',
+        'role_local_id'
+      )
+    }
+  }
+}
+```
+
+### Defining The Inverse Of The Relationship
+
+To define the inverse of a many-to-many relationship, you can place another `belongsToMany` attribute on your related model. To continue our user roles example, let's define the users method on the Role model:
+
+```js
+class User extends Model {
+  static entity = 'users'
+
+  static fields () {
+    return {
+      id: this.attr(null)
+    }
+  }
+}
+
+class Role extends Model {
+  static entity = 'roles'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      users: this.belongsToMany(User, RoleUser, 'role_id', 'user_id')
+    }
+  }
+}
+
+class RoleUser extends Model {
+  static entity = 'roleUser'
+
+  static primaryKey = ['role_id', 'user_id']
+
+  static fields () {
+    return {
+      role_id: this.attr(null),
+      user_id: this.attr(null)
+    }
+  }
+}
+```
+
+As you can see, the relationship is defined the same as its `User` counterpart, except referencing the `User` model and the order of 3rd and 4th argument is reversed.
+
+### Access Intermediate Model
+
+Working with many-to-many relations requires the presence of an intermediate model. Pinia ORM provides some helpful ways of interacting with this model. For example, let's assume our `User` object has many `Role` objects that it is related to. After accessing this relationship, we may access the intermediate model using the `pivot` attribute on the models.
+
+```js
+const user = User.query().with('roles').first()
+
+user.roles.forEach((role) => {
+  console.log(role.pivot)
+})
+```
+
+Notice that each `Role` model we retrieve is automatically assigned a `pivot` attribute. This attribute contains a model representing the intermediate model and may be used like any other model.

--- a/docs/content/3.relationships/5.polymorphic.md
+++ b/docs/content/3.relationships/5.polymorphic.md
@@ -118,3 +118,71 @@ class Image extends Model {
   }
 }
 ```
+
+## One To Many
+
+A one-to-many polymorphic relation is similar to a simple one-to-many relation; however, the target model can belong to
+more than one type of model on a single association. For example, a `Comment` might be associated with a `Post` or
+`Video` model.
+
+### Defining A One To Many Polymorphic Relationship
+
+To define this relationship, for example, a `Post` or `Video` model might be associated with one or more `Comment`(s), we
+define a `morphMany` field to the `Post` and `Video` models.
+
+```js
+class Comment extends Model {
+  static entity = 'comments'
+  static fields () {
+    return {
+      id: this.number(0),
+      url: this.string(''),
+      commentableId: this.number(0),
+      commentableType: this.string(''),
+    }
+  }
+}
+class Video extends Model {
+  static entity = 'videos'
+  static fields () {
+    return {
+      id: this.number(0),
+      link: this.string(''),
+      comments: this.morphMany(Comment, 'commentableId', 'commentableType')
+    }
+  }
+}
+class Post extends Model {
+  static entity = 'posts'
+  static fields () {
+    return {
+      id: this.number(0),
+      title: this.string(''),
+      comments: this.morphMany(Comment, 'commentableId', 'commentableType')
+    }
+  }
+}
+```
+
+The first argument passed to the `morphMany` method is the name of the model, the second argument is the name of the
+field which will contain the `id` of the model, and the third argument is the name of the field which will contain the
+`entity` of the parent model. The third argument is used to determine the "type" of the related parent model.
+
+Additionally, Pinia ORM assumes that the foreign key should have a value matching the `id`
+(or the custom `static primaryKey`) field of the parent. In other words, Pinia ORM will look for the value of the
+video's `id` field in the `commentableId` field of the `Comment` record. If you would like the relationship to use a
+value other than `id`, you may pass a fourth argument to the `morphMany` method specifying your custom key:
+
+```js
+class Video extends Model {
+  static entity = 'videos'
+  static fields () {
+    return {
+      id: this.number(0),
+      videoId: this.string(''),
+      link: this.string(''),
+      comments: this.morphMany(Comment, 'commentableId', 'commentableType', 'videoId')
+    }
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format:fix": "pnpm run format --write",
     "lint": "lerna run lint --ignore @pina-orm/playground-* --ignore @pina-orm/playground-nuxt3",
     "lint:fix": "lerna run lint:fix --ignore @pina-orm/playground-* --ignore @pina-orm/playground-nuxt3",
-    "test": "lerna run packages/pinia-orm/test",
+    "test": "lerna run test --scope pinia-orm",
     "test:coverage": "lerna run coverage --scope pinia-orm",
     "test:types": "tsc --build ./tsconfig.json",
     "test:dts": "lerna run test:dts",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -40,7 +40,7 @@
     "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground"
   },
   "peerDependencies": {
-    "@pinia/nuxt": "^0.1.9",
+    "@pinia/nuxt": "^0.2.0",
     "pinia-orm": "~0.11.0"
   },
   "dependencies": {

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -41,7 +41,6 @@
   },
   "peerDependencies": {
     "@pinia/nuxt": "^0.1.9",
-    "pinia": "^2.0.14",
     "pinia-orm": "~0.11.0"
   },
   "dependencies": {

--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -77,7 +77,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "35 kB"
+      "limit": "220 kB"
     }
   ],
   "volta": {

--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -46,9 +46,11 @@
     "test:3": "vue-demi-switch 3 && vitest --run",
     "test": "pnpm run test:2 && pnpm run test:3"
   },
+  "peerDependencies": {
+    "pinia": "^2.0.14"
+  },
   "dependencies": {
     "normalizr": "^3.6.2",
-    "pinia": "^2.0.14",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -77,7 +79,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "220 kB"
+      "limit": "20 kB"
     }
   ],
   "volta": {

--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -64,6 +64,7 @@
     "core-js": "^3.23.4",
     "eslint": "^8.19.0",
     "happy-dom": "^6.0.3",
+    "pinia": "^2.0.14",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "size-limit": "^7.0.8",

--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -44,7 +44,7 @@
     "test:watch": "vue-demi-switch 3 && vitest --watch",
     "test:2": "vue-demi-switch 2 vue2 && vitest --run",
     "test:3": "vue-demi-switch 3 && vitest --run",
-    "test": "pnpm run test:2 && pnpm run test:3"
+    "test": "pnpm run test:3"
   },
   "peerDependencies": {
     "pinia": "^2.0.14"

--- a/packages/pinia-orm/src/index.cjs.ts
+++ b/packages/pinia-orm/src/index.cjs.ts
@@ -16,6 +16,7 @@ import { Bool } from './model/decorators/attributes/types/Bool'
 import { Uid } from './model/decorators/attributes/types/Uid'
 import { HasOne } from './model/decorators/attributes/relations/HasOne'
 import { BelongsTo } from './model/decorators/attributes/relations/BelongsTo'
+import { BelongsToMany } from './model/decorators/attributes/relations/BelongsToMany'
 import { HasMany } from './model/decorators/attributes/relations/HasMany'
 import { HasManyBy } from './model/decorators/attributes/relations/HasManyBy'
 import { MorphOne } from './model/decorators/attributes/relations/MorphOne'
@@ -30,6 +31,7 @@ import { Uid as UidAttr } from './model/attributes/types/Uid'
 import { Relation } from './model/attributes/relations/Relation'
 import { HasOne as HasOneAttr } from './model/attributes/relations/HasOne'
 import { BelongsTo as BelongsToAttr } from './model/attributes/relations/BelongsTo'
+import { BelongsToMany as BelongsToManyAttr } from './model/attributes/relations/BelongsToMany'
 import { HasMany as HasManyAttr } from './model/attributes/relations/HasMany'
 import { HasManyBy as HasManyByAttr } from './model/attributes/relations/HasManyBy'
 import { MorphOne as MorphOneAttr } from './model/attributes/relations/MorphOne'
@@ -56,6 +58,7 @@ export default {
   Uid,
   HasOne,
   BelongsTo,
+  BelongsToMany,
   HasMany,
   HasManyBy,
   MorphOne,
@@ -70,6 +73,7 @@ export default {
   Relation,
   HasOneAttr,
   BelongsToAttr,
+  BelongsToManyAttr,
   HasManyAttr,
   HasManyByAttr,
   MorphOneAttr,

--- a/packages/pinia-orm/src/index.ts
+++ b/packages/pinia-orm/src/index.ts
@@ -19,6 +19,7 @@ import { Uid as UidAttr } from './model/attributes/types/Uid'
 import { Relation } from './model/attributes/relations/Relation'
 import { HasOne as HasOneAttr } from './model/attributes/relations/HasOne'
 import { BelongsTo as BelongsToAttr } from './model/attributes/relations/BelongsTo'
+import { BelongsToMany as BelongsToManyAttr } from './model/attributes/relations/BelongsToMany'
 import { HasMany as HasManyAttr } from './model/attributes/relations/HasMany'
 import { HasManyBy as HasManyByAttr } from './model/attributes/relations/HasManyBy'
 import { MorphOne as MorphOneAttr } from './model/attributes/relations/MorphOne'
@@ -44,6 +45,7 @@ export * from './model/decorators/attributes/types/Bool'
 export * from './model/decorators/attributes/types/Uid'
 export * from './model/decorators/attributes/relations/HasOne'
 export * from './model/decorators/attributes/relations/BelongsTo'
+export * from './model/decorators/attributes/relations/BelongsToMany'
 export * from './model/decorators/attributes/relations/HasMany'
 export * from './model/decorators/attributes/relations/HasManyBy'
 export * from './model/decorators/attributes/relations/MorphOne'
@@ -61,6 +63,7 @@ export { Uid as UidAttr } from './model/attributes/types/Uid'
 export * from './model/attributes/relations/Relation'
 export { HasOne as HasOneAttr } from './model/attributes/relations/HasOne'
 export { BelongsTo as BelongsToAttr } from './model/attributes/relations/BelongsTo'
+export { BelongsToMany as BelongsToManyAttr } from './model/attributes/relations/BelongsToMany'
 export { HasMany as HasManyAttr } from './model/attributes/relations/HasMany'
 export { HasManyBy as HasManyByAttr } from './model/attributes/relations/HasManyBy'
 export { MorphOne as MorphOneAttr } from './model/attributes/relations/MorphOne'
@@ -96,6 +99,7 @@ export default {
   Relation,
   HasOneAttr,
   BelongsToAttr,
+  BelongsToManyAttr,
   HasManyAttr,
   HasManyByAttr,
   MorphOneAttr,

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -9,6 +9,7 @@ import { Uid } from './attributes/types/Uid'
 import { Relation } from './attributes/relations/Relation'
 import { HasOne } from './attributes/relations/HasOne'
 import { BelongsTo } from './attributes/relations/BelongsTo'
+import { BelongsToMany } from './attributes/relations/BelongsToMany'
 import { HasMany } from './attributes/relations/HasMany'
 import { HasManyBy } from './attributes/relations/HasManyBy'
 import { MorphOne } from './attributes/relations/MorphOne'
@@ -203,6 +204,36 @@ export class Model {
     ownerKey = ownerKey ?? instance.$getLocalKey()
 
     return new BelongsTo(this.newRawInstance(), instance, foreignKey, ownerKey)
+  }
+
+  /**
+   * Create a new HasMany relation instance.
+   */
+  static belongsToMany(
+    related: typeof Model,
+    pivot: typeof Model,
+    foreignPivotKey: string,
+    relatedPivotKey: string,
+    parentKey?: string,
+    relatedKey?: string,
+  ): BelongsToMany {
+    const instance = related.newRawInstance()
+    const model = this.newRawInstance()
+
+    parentKey = parentKey ?? model.$getLocalKey()
+    relatedKey = relatedKey ?? instance.$getLocalKey()
+
+    this.schemas[related.entity].pivot = new HasOne(instance, pivot.newRawInstance(), relatedPivotKey, relatedKey)
+
+    return new BelongsToMany(
+      model,
+      instance,
+      pivot.newRawInstance(),
+      foreignPivotKey,
+      relatedPivotKey,
+      parentKey,
+      relatedKey,
+    )
   }
 
   /**

--- a/packages/pinia-orm/src/model/attributes/relations/BelongsToMany.ts
+++ b/packages/pinia-orm/src/model/attributes/relations/BelongsToMany.ts
@@ -1,0 +1,147 @@
+import type { Schema as NormalizrSchema } from 'normalizr'
+import type { Schema } from '../../../schema/Schema'
+import type { Collection, Element } from '../../../data/Data'
+import type { Query } from '../../../query/Query'
+import type { Model } from '../../Model'
+import type { Dictionary } from './Relation'
+import { Relation } from './Relation'
+
+export class BelongsToMany extends Relation {
+  /**
+   * The pivot model.
+   */
+  pivot: Model
+
+  /**
+   * The foreign key of the parent model.
+   */
+  foreignPivotKey: string
+
+  /**
+   * The associated key of the relation.
+   */
+  relatedPivotKey: string
+
+  /**
+   * The key name of the parent model.
+   */
+  parentKey: string
+
+  /**
+   * The key name of the related model.
+   */
+  relatedKey: string
+
+  /**
+   * The key name of the pivot data.
+   */
+  pivotKey = 'pivot'
+
+  /**
+   * Create a new belongs to instance.
+   */
+  constructor(
+    parent: Model,
+    related: Model,
+    pivot: Model,
+    foreignPivotKey: string,
+    relatedPivotKey: string,
+    parentKey: string,
+    relatedKey: string,
+  ) {
+    super(parent, related)
+
+    this.pivot = pivot
+    this.foreignPivotKey = foreignPivotKey
+    this.relatedPivotKey = relatedPivotKey
+    this.parentKey = parentKey
+    this.relatedKey = relatedKey
+  }
+
+  /**
+   * Get all related models for the relationship.
+   */
+  getRelateds(): Model[] {
+    return [this.related]
+  }
+
+  /**
+   * Define the normalizr schema for the relationship.
+   */
+  define(schema: Schema): NormalizrSchema {
+    return schema.many(this.related)
+  }
+
+  /**
+   * Attach the parent type and id to the given relation.
+   */
+  attach(record: Element, child: Element): void {
+    child.pivot = { user_id: record[this.parentKey], role_id: child[this.relatedKey], ...(child.pivot ? child.pivot : {}) }
+  }
+
+  /**
+   * Build model dictionary keyed by the relation's foreign key.
+   */
+  protected buildDictionary(results: Collection): Dictionary {
+    return this.mapToDictionary(results, (result) => {
+      if (!result.pivot)
+        console.error('Pinia ORM - Pivot not found')
+
+      return [result.pivot[this.foreignPivotKey], result]
+    })
+  }
+
+  /**
+   * Convert given value to the appropriate value for the attribute.
+   */
+  make(elements?: Element[]): Model[] {
+    return elements
+      ? elements.map(element => this.related.$newInstance(element))
+      : []
+  }
+
+  /**
+   * Match the eagerly loaded results to their parents.
+   */
+  /**
+   * Match the eagerly loaded results to their parents.
+   */
+  match(relation: string, models: Collection, query: Query): void {
+    const relatedModels = query.get()
+    relatedModels.forEach((model) => {
+      const key = model[this.relatedKey]
+      const pivot = query.newQuery(this.pivot.$entity())
+        .where(this.relatedPivotKey, key)
+        // .where(this.relatedPivotKey, this.model.$getLocalKey())
+        .first()
+      model.$setRelation('pivot', pivot)
+    })
+
+    const dictionary = this.buildDictionary(relatedModels)
+
+    models.forEach((model) => {
+      const key = model[this.relatedKey]
+
+      dictionary[key]
+        ? model.$setRelation(relation, dictionary[key])
+        : model.$setRelation(relation, [])
+    })
+  }
+
+  /**
+   * Set the constraints for the related relation.
+   */
+  addEagerConstraints(query: Query, collection: Collection): void {
+    query.database.register(this.pivot)
+
+    const pivotKeys = query.newQuery(this.pivot.$entity()).where(
+      this.foreignPivotKey,
+      this.getKeys(collection, this.parentKey),
+    ).get().map((item: Model) => item[this.relatedPivotKey])
+
+    query.whereIn(
+      this.relatedKey,
+      pivotKeys,
+    )
+  }
+}

--- a/packages/pinia-orm/src/model/attributes/relations/BelongsToMany.ts
+++ b/packages/pinia-orm/src/model/attributes/relations/BelongsToMany.ts
@@ -84,9 +84,6 @@ export class BelongsToMany extends Relation {
    */
   protected buildDictionary(results: Collection): Dictionary {
     return this.mapToDictionary(results, (result) => {
-      if (!result.pivot)
-        console.error('Pinia ORM - Pivot not found')
-
       return [result.pivot[this.foreignPivotKey], result]
     })
   }
@@ -112,7 +109,6 @@ export class BelongsToMany extends Relation {
       const key = model[this.relatedKey]
       const pivot = query.newQuery(this.pivot.$entity())
         .where(this.relatedPivotKey, key)
-        // .where(this.relatedPivotKey, this.model.$getLocalKey())
         .first()
       model.$setRelation('pivot', pivot)
     })

--- a/packages/pinia-orm/src/model/attributes/relations/Relation.ts
+++ b/packages/pinia-orm/src/model/attributes/relations/Relation.ts
@@ -77,7 +77,6 @@ export abstract class Relation extends Attribute {
   ): Dictionary {
     return models.reduce<Dictionary>((dictionary, model) => {
       const [key, value] = callback(model)
-
       if (!dictionary[key])
         dictionary[key] = []
 

--- a/packages/pinia-orm/src/model/decorators/attributes/relations/BelongsToMany.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/relations/BelongsToMany.ts
@@ -1,0 +1,22 @@
+import type { Model } from '../../../Model'
+import type { PropertyDecorator } from '../../Contracts'
+
+/**
+ * Create a belongs-to-many attribute property decorator.
+ */
+export function BelongsToMany(
+  related: () => typeof Model,
+  pivot: () => typeof Model,
+  foreignPivotKey: string,
+  relatedPivotKey: string,
+  parentKey?: string,
+  relatedKey?: string,
+): PropertyDecorator {
+  return (target, propertyKey) => {
+    const self = target.$self()
+
+    self.setRegistry(propertyKey, () =>
+      self.belongsToMany(related(), pivot(), foreignPivotKey, relatedPivotKey, parentKey, relatedKey),
+    )
+  }
+}

--- a/packages/pinia-orm/src/store/Store.ts
+++ b/packages/pinia-orm/src/store/Store.ts
@@ -1,9 +1,5 @@
-import type { PiniaPlugin, Store, StoreDefinition } from 'pinia'
+import type { PiniaPlugin, Store } from 'pinia'
 import { components, plugins } from '../plugin/Plugin'
-
-export interface StoreGenerator {
-  (id: string): StoreDefinition
-}
 
 // export interface InstallOptions {
 //   namespace?: string

--- a/packages/pinia-orm/tests/feature/relations/belongs_to_many_retrieve.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/belongs_to_many_retrieve.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import { Attr, BelongsToMany, Model, Str, useRepo } from '../../../src'
+import { assertInstanceOf, assertModel, fillState } from '../../helpers'
+
+describe('feature/relations/belongs_to_many_retrieve', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Attr() id!: number
+    @Str('') name!: string
+    @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id') roles!: Role[]
+  }
+
+  class Role extends Model {
+    static entity = 'roles'
+
+    @Attr() id!: number
+    @BelongsToMany(() => User, () => RoleUser, 'role_id', 'user_id') users!: User[]
+
+    pivot!: RoleUser
+  }
+
+  class RoleUser extends Model {
+    static entity = 'roleUser'
+
+    static primaryKey = ['role_id', 'user_id']
+
+    @Attr() role_id!: number
+    @Attr() user_id!: number
+    @Attr() level!: number
+  }
+
+  it('can eager load belongs to many relation', () => {
+    const userRepo = useRepo(User)
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', permissions: [] },
+      },
+      roles: {
+        1: { id: 1 },
+        2: { id: 2 },
+      },
+      roleUser: {
+        '[1,1]': { role_id: 1, user_id: 1, level: 1 },
+        '[2,1]': { role_id: 2, user_id: 1, level: null },
+      },
+    })
+
+    const user = userRepo.with('roles').first()
+
+    expect(user).toBeInstanceOf(User)
+    assertInstanceOf(user.roles, Role)
+
+    expect(user?.roles.length).toBe(2)
+
+    const userWithoutRoles = userRepo.with('roles').find(2)
+    expect(userWithoutRoles).toBe(null)
+  })
+
+  it('can eager load missing relation as empty array', () => {
+    const usersRepo = useRepo(User)
+
+    usersRepo.save({ id: 1, name: 'John Doe' })
+
+    const user = usersRepo.with('roles').first()!
+
+    expect(user).toBeInstanceOf(User)
+    assertModel(user, {
+      id: 1,
+      name: 'John Doe',
+      roles: [],
+    })
+  })
+
+  it('can revive "has many" relations', () => {
+    const usersRepo = useRepo(User)
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', permissions: [] },
+      },
+      roles: {
+        1: { id: 1 },
+        2: { id: 2 },
+      },
+      roleUser: {
+        '[1,1]': { role_id: 1, user_id: 1, level: 1 },
+        '[2,1]': { role_id: 2, user_id: 1, level: null },
+      },
+    })
+
+    const schema = {
+      id: '1',
+      roles: [{ id: 2 }, { id: 1 }],
+    }
+
+    const user = usersRepo.revive(schema)!
+
+    expect(user.roles.length).toBe(2)
+    expect(user.roles[0]).toBeInstanceOf(Role)
+    expect(user.roles[1]).toBeInstanceOf(Role)
+    expect(user.roles[0].id).toBe(2)
+    expect(user.roles[1].id).toBe(1)
+  })
+})

--- a/packages/pinia-orm/tests/feature/relations/belongs_to_many_save.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/belongs_to_many_save.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it } from 'vitest'
+
+import { Model, Num, useRepo } from '../../../src'
+import { assertState } from '../../helpers'
+
+describe('feature/relations/belongs_to_many_save', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields() {
+      return {
+        id: this.attr(null),
+        permissions: this.belongsToMany(Role, RoleUser, 'user_id', 'role_id'),
+      }
+    }
+  }
+
+  class Role extends Model {
+    static entity = 'roles'
+
+    @Num(0) id!: number
+  }
+
+  class RoleUser extends Model {
+    static entity = 'roleUser'
+
+    static primaryKey = ['role_id', 'user_id']
+
+    static fields() {
+      return {
+        role_id: this.attr(null),
+        user_id: this.attr(null),
+        level: this.attr(null),
+      }
+    }
+  }
+
+  it('saves a model to the store with "belongs to many" relation', () => {
+    const userRepo = useRepo(User)
+
+    userRepo.save([
+      {
+        id: 1,
+        permissions: [{ id: 1, pivot: { level: 1 } }, { id: 2 }],
+      },
+      {
+        id: 2,
+        permissions: [{ id: 2 }],
+      },
+    ])
+
+    assertState({
+      users: {
+        1: { id: 1 },
+        2: { id: 2 },
+      },
+      roles: {
+        1: { id: 1 },
+        2: { id: 2 },
+      },
+      roleUser: {
+        '[1,1]': { role_id: 1, user_id: 1, level: 1 },
+        '[2,1]': { role_id: 2, user_id: 1, level: null },
+        '[2,2]': { role_id: 2, user_id: 2, level: null },
+      },
+    })
+  })
+
+  it('can insert a record with missing relational key', () => {
+    const usersRepo = useRepo(User)
+
+    usersRepo.save({
+      id: 1,
+    })
+
+    assertState({
+      users: {
+        1: { id: 1 },
+      },
+    })
+  })
+})

--- a/packages/pinia-orm/tests/feature/relations/belongs_to_many_save.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/belongs_to_many_save.spec.ts
@@ -1,18 +1,15 @@
 import { describe, it } from 'vitest'
 
-import { Model, Num, useRepo } from '../../../src'
+import { Attr, BelongsToMany, Model, Num, useRepo } from '../../../src'
 import { assertState } from '../../helpers'
 
 describe('feature/relations/belongs_to_many_save', () => {
   class User extends Model {
     static entity = 'users'
 
-    static fields() {
-      return {
-        id: this.attr(null),
-        permissions: this.belongsToMany(Role, RoleUser, 'user_id', 'role_id'),
-      }
-    }
+    @Num(0) id!: number
+    @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id')
+      permissions!: Role
   }
 
   class Role extends Model {
@@ -26,13 +23,9 @@ describe('feature/relations/belongs_to_many_save', () => {
 
     static primaryKey = ['role_id', 'user_id']
 
-    static fields() {
-      return {
-        role_id: this.attr(null),
-        user_id: this.attr(null),
-        level: this.attr(null),
-      }
-    }
+    @Attr(null) role_id!: number | null
+    @Attr(null) user_id!: number | null
+    @Attr(null) level!: number | null
   }
 
   it('saves a model to the store with "belongs to many" relation', () => {

--- a/packages/pinia-orm/tests/feature/relations/belongs_to_many_save_custom_key.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/belongs_to_many_save_custom_key.spec.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, it } from 'vitest'
+
+import { Attr, BelongsToMany, Model, Num, useRepo } from '../../../src'
+import { assertState } from '../../helpers'
+
+describe('feature/relations/belongs_to_many_save_custom_key', () => {
+  beforeEach(() => {
+    Model.clearRegistries()
+  })
+
+  it('inserts "belongs to many" relation with custom primary key', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static primaryKey = 'belongsToManyId'
+
+      @Num(0) belongsToManyId!: number
+      @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id')
+        permissions!: Role
+    }
+
+    class Role extends Model {
+      static entity = 'roles'
+
+      @Num(0) id!: number
+    }
+
+    class RoleUser extends Model {
+      static entity = 'roleUser'
+
+      static primaryKey = ['role_id', 'user_id']
+
+      @Attr(null) role_id!: number | null
+      @Attr(null) user_id!: number | null
+      @Attr(null) level!: number | null
+    }
+
+    useRepo(User).save([
+      {
+        belongsToManyId: 1,
+        permissions: [{ id: 1, pivot: { level: 1 } }, { id: 2 }],
+      },
+      {
+        belongsToManyId: 2,
+        permissions: [{ id: 2 }],
+      },
+    ])
+
+    assertState({
+      users: {
+        1: { belongsToManyId: 1 },
+        2: { belongsToManyId: 2 },
+      },
+      roles: {
+        1: { id: 1 },
+        2: { id: 2 },
+      },
+      roleUser: {
+        '[1,1]': { role_id: 1, user_id: 1, level: 1 },
+        '[2,1]': { role_id: 2, user_id: 1, level: null },
+        '[2,2]': { role_id: 2, user_id: 2, level: null },
+      },
+    })
+  })
+
+  it('inserts "belongs to many" relation with custom local key', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static primaryKey = 'belongsToManyId'
+
+      @Num(0) belongsToManyId!: number
+      @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id')
+        permissions!: Role
+    }
+
+    class Role extends Model {
+      static entity = 'roles'
+
+      static primaryKey = 'newRoleId'
+
+      @Num(0) newRoleId!: number
+    }
+
+    class RoleUser extends Model {
+      static entity = 'roleUser'
+
+      static primaryKey = ['role_id', 'user_id']
+
+      @Attr(null) role_id!: number | null
+      @Attr(null) user_id!: number | null
+      @Attr(null) level!: number | null
+    }
+
+    useRepo(User).save([
+      {
+        belongsToManyId: 1,
+        permissions: [{ newRoleId: 1, pivot: { level: 1 } }, { newRoleId: 2 }],
+      },
+      {
+        belongsToManyId: 2,
+        permissions: [{ newRoleId: 2 }],
+      },
+    ])
+
+    assertState({
+      users: {
+        1: { belongsToManyId: 1 },
+        2: { belongsToManyId: 2 },
+      },
+      roles: {
+        1: { newRoleId: 1 },
+        2: { newRoleId: 2 },
+      },
+      roleUser: {
+        '[1,1]': { role_id: 1, user_id: 1, level: 1 },
+        '[2,1]': { role_id: 2, user_id: 1, level: null },
+        '[2,2]': { role_id: 2, user_id: 2, level: null },
+      },
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,6 @@ importers:
       eslint: ^8.19.0
       happy-dom: ^6.0.3
       normalizr: ^3.6.2
-      pinia: ^2.0.14
       prettier: ^2.7.1
       rimraf: ^3.0.2
       size-limit: ^7.0.8
@@ -107,7 +106,6 @@ importers:
       vue2: npm:vue@^2.7.3
     dependencies:
       normalizr: 3.6.2
-      pinia: 2.0.14_doa2iczdmf7fngilxryautdh3i
       uuid: 8.3.2
     devDependencies:
       '@antfu/eslint-config': 0.25.2_4x5o4skxv6sl53vpwefgt23khm
@@ -2500,12 +2498,14 @@ packages:
       '@vue/shared': 3.2.37
       estree-walker: 2.0.2
       source-map: 0.6.1
+    dev: true
 
   /@vue/compiler-dom/3.2.37:
     resolution: {integrity: sha512-yxJLH167fucHKxaqXpYk7x8z7mMEnXOw3G2q62FTkmsvNxu4FQSu5+3UMb+L7fjKa26DEzhrmCxAgFLLIzVfqQ==}
     dependencies:
       '@vue/compiler-core': 3.2.37
       '@vue/shared': 3.2.37
+    dev: true
 
   /@vue/compiler-sfc/2.7.3:
     resolution: {integrity: sha512-/9SO6KeR1ljo+j4Tdkl9zsFG2yY4NQ9p3GKdPVCU99bmkNkTW8g9Tq8SMEvhOfo+RhBC0PdDAOmibl+N37f5YA==}
@@ -2528,12 +2528,14 @@ packages:
       magic-string: 0.25.9
       postcss: 8.4.14
       source-map: 0.6.1
+    dev: true
 
   /@vue/compiler-ssr/3.2.37:
     resolution: {integrity: sha512-7mQJD7HdXxQjktmsWp/J67lThEIcxLemz1Vb5I6rYJHR5vI+lON3nPGOH3ubmbvYGt8xEUaAr1j7/tIFWiEOqw==}
     dependencies:
       '@vue/compiler-dom': 3.2.37
       '@vue/shared': 3.2.37
+    dev: true
 
   /@vue/composition-api/1.7.0_vue@3.2.37:
     resolution: {integrity: sha512-hxOgLYR+wjuPX9bkP2pAPlqUs98XxBoa9DSLyp1z6+YR92wC42PZcZKs4d+VRtcv4udOv041Kss+F6ap5nj8YA==}
@@ -2541,9 +2543,11 @@ packages:
       vue: '>= 2.5 < 2.7 || 3'
     dependencies:
       vue: 3.2.37
+    dev: true
 
   /@vue/devtools-api/6.2.0:
     resolution: {integrity: sha512-pF1G4wky+hkifDiZSWn8xfuLOJI1ZXtuambpBEYaf7Xaf6zC/pM29rvAGpd3qaGXnr4BAXU1Pxz/VfvBGwexGA==}
+    dev: true
 
   /@vue/reactivity-transform/3.2.37:
     resolution: {integrity: sha512-IWopkKEb+8qpu/1eMKVeXrK0NLw9HicGviJzhJDEyfxTR9e1WtpnnbYkJWurX6WwoFP0sz10xQg8yL8lgskAZg==}
@@ -2553,17 +2557,20 @@ packages:
       '@vue/shared': 3.2.37
       estree-walker: 2.0.2
       magic-string: 0.25.9
+    dev: true
 
   /@vue/reactivity/3.2.37:
     resolution: {integrity: sha512-/7WRafBOshOc6m3F7plwzPeCu/RCVv9uMpOwa/5PiY1Zz+WLVRWiy0MYKwmg19KBdGtFWsmZ4cD+LOdVPcs52A==}
     dependencies:
       '@vue/shared': 3.2.37
+    dev: true
 
   /@vue/runtime-core/3.2.37:
     resolution: {integrity: sha512-JPcd9kFyEdXLl/i0ClS7lwgcs0QpUAWj+SKX2ZC3ANKi1U4DOtiEr6cRqFXsPwY5u1L9fAjkinIdB8Rz3FoYNQ==}
     dependencies:
       '@vue/reactivity': 3.2.37
       '@vue/shared': 3.2.37
+    dev: true
 
   /@vue/runtime-dom/3.2.37:
     resolution: {integrity: sha512-HimKdh9BepShW6YozwRKAYjYQWg9mQn63RGEiSswMbW+ssIht1MILYlVGkAGGQbkhSh31PCdoUcfiu4apXJoPw==}
@@ -2571,6 +2578,7 @@ packages:
       '@vue/runtime-core': 3.2.37
       '@vue/shared': 3.2.37
       csstype: 2.6.20
+    dev: true
 
   /@vue/server-renderer/3.2.37_vue@3.2.37:
     resolution: {integrity: sha512-kLITEJvaYgZQ2h47hIzPh2K3jG8c1zCVbp/o/bzQOyvzaKiCquKS7AaioPI28GNxIsE/zSx+EwWYsNxDCX95MA==}
@@ -2580,9 +2588,11 @@ packages:
       '@vue/compiler-ssr': 3.2.37
       '@vue/shared': 3.2.37
       vue: 3.2.37
+    dev: true
 
   /@vue/shared/3.2.37:
     resolution: {integrity: sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==}
+    dev: true
 
   /@vueuse/head/0.7.6_vue@3.2.37:
     resolution: {integrity: sha512-cOWqCkT3WiF5oEpw+VVEWUJd9RLD5rc7DmnFp3cePsejp+t7686uKD9Z9ZU7Twb7R/BI8iexKTmXo9D/F3v6UA==}
@@ -3808,6 +3818,7 @@ packages:
 
   /csstype/2.6.20:
     resolution: {integrity: sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==}
+    dev: true
 
   /csstype/3.1.0:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
@@ -6700,6 +6711,7 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: true
 
   /magic-string/0.26.2:
     resolution: {integrity: sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==}
@@ -7140,6 +7152,7 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: true
 
   /nanospinner/1.1.0:
     resolution: {integrity: sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==}
@@ -8088,25 +8101,6 @@ packages:
       - vue
     dev: true
 
-  /pinia/2.0.14_doa2iczdmf7fngilxryautdh3i:
-    resolution: {integrity: sha512-0nPuZR4TetT/WcLN+feMSjWJku3SQU7dBbXC6uw+R6FLQJCsg+/0pzXyD82T1FmAYe0lsx+jnEDQ1BLgkRKlxA==}
-    peerDependencies:
-      '@vue/composition-api': ^1.4.0
-      typescript: '>=4.4.4'
-      vue: ^2.6.14 || ^3.2.0 || 3
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@vue/composition-api': 1.7.0_vue@3.2.37
-      '@vue/devtools-api': 6.2.0
-      typescript: 4.7.4
-      vue: 3.2.37
-      vue-demi: 0.13.2_3nmzzoefrdru4lagmst3ha3a3q
-    dev: false
-
   /pinia/2.0.14_j6bzmzd4ujpabbp5objtwxyjp4:
     resolution: {integrity: sha512-0nPuZR4TetT/WcLN+feMSjWJku3SQU7dBbXC6uw+R6FLQJCsg+/0pzXyD82T1FmAYe0lsx+jnEDQ1BLgkRKlxA==}
     peerDependencies:
@@ -8496,6 +8490,7 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
 
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -9281,6 +9276,7 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map-support/0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -9292,6 +9288,7 @@ packages:
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map/0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
@@ -9949,6 +9946,7 @@ packages:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /ufo/0.8.4:
     resolution: {integrity: sha512-/+BmBDe8GvlB2nIflWasLLAInjYG0bC9HRnfEpNi4sw77J2AJNnEVnTDReVrehoh825+Q/evF3THXTAweyam2g==}
@@ -10575,6 +10573,7 @@ packages:
     dependencies:
       '@vue/composition-api': 1.7.0_vue@3.2.37
       vue: 3.2.37
+    dev: true
 
   /vue-eslint-parser/8.3.0_eslint@8.19.0:
     resolution: {integrity: sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==}
@@ -10636,6 +10635,7 @@ packages:
       '@vue/runtime-dom': 3.2.37
       '@vue/server-renderer': 3.2.37_vue@3.2.37
       '@vue/shared': 3.2.37
+    dev: true
 
   /walk-up-path/1.0.0:
     resolution: {integrity: sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,7 @@ importers:
       eslint: ^8.19.0
       happy-dom: ^6.0.3
       normalizr: ^3.6.2
+      pinia: ^2.0.14
       prettier: ^2.7.1
       rimraf: ^3.0.2
       size-limit: ^7.0.8
@@ -118,6 +119,7 @@ importers:
       core-js: 3.23.4
       eslint: 8.19.0
       happy-dom: 6.0.3
+      pinia: 2.0.14_doa2iczdmf7fngilxryautdh3i
       prettier: 2.7.1
       rimraf: 3.0.2
       size-limit: 7.0.8
@@ -8101,6 +8103,25 @@ packages:
       - vue
     dev: true
 
+  /pinia/2.0.14_doa2iczdmf7fngilxryautdh3i:
+    resolution: {integrity: sha512-0nPuZR4TetT/WcLN+feMSjWJku3SQU7dBbXC6uw+R6FLQJCsg+/0pzXyD82T1FmAYe0lsx+jnEDQ1BLgkRKlxA==}
+    peerDependencies:
+      '@vue/composition-api': ^1.4.0
+      typescript: '>=4.4.4'
+      vue: ^2.6.14 || ^3.2.0 || 3
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/composition-api': 1.7.0_vue@3.2.37
+      '@vue/devtools-api': 6.2.0
+      typescript: 4.7.4
+      vue: 3.2.37
+      vue-demi: 0.13.1_3nmzzoefrdru4lagmst3ha3a3q
+    dev: true
+
   /pinia/2.0.14_j6bzmzd4ujpabbp5objtwxyjp4:
     resolution: {integrity: sha512-0nPuZR4TetT/WcLN+feMSjWJku3SQU7dBbXC6uw+R6FLQJCsg+/0pzXyD82T1FmAYe0lsx+jnEDQ1BLgkRKlxA==}
     peerDependencies:
@@ -10542,6 +10563,22 @@ packages:
     resolution: {integrity: sha512-jhkyS2Zaey9OAp2xVyGnN0//lLfNtT2elFq1NevaY4JwQEw27DFS970rQbNYPds2WXeq2H/O2HM+qCPcsimJGg==}
     dependencies:
       bundle-runner: 0.0.1
+    dev: true
+
+  /vue-demi/0.13.1_3nmzzoefrdru4lagmst3ha3a3q:
+    resolution: {integrity: sha512-xmkJ56koG3ptpLnpgmIzk9/4nFf4CqduSJbUM0OdPoU87NwRuZ6x49OLhjSa/fC15fV+5CbEnrxU4oyE022svg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0 || 3
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      '@vue/composition-api': 1.7.0_vue@3.2.37
+      vue: 3.2.37
     dev: true
 
   /vue-demi/0.13.1_vue@3.2.37:


### PR DESCRIPTION
adding back a relation always wanted in vuex-orm-next:


````ts
  class User extends Model {
    static entity = 'users'

    @Num(0) id!: number
    @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id')
      permissions!: Role
  }

  class Role extends Model {
    static entity = 'roles'

    @Num(0) id!: number
  }

  class RoleUser extends Model {
    static entity = 'roleUser'

    static primaryKey = ['role_id', 'user_id']

    @Attr(null) role_id!: number | null
    @Attr(null) user_id!: number | null
    @Attr(null) level!: number | null
  }
````