### PR TITLE
feat(pinia-orm): add life-cycle-hooks

### DIFF
--- a/docs/content/2.model/4.lifecycle-hooks.md
+++ b/docs/content/2.model/4.lifecycle-hooks.md
@@ -1,0 +1,132 @@
+---
+title: Lifecycle Hooks
+description: ''
+---
+
+# Lifecycle Hooks
+
+Pinia ORM fires several lifecycle hooks while interacting with the store, allowing you to hook into the particular points in a query lifecycle. Lifecycle hooks allow you to easily execute code each time a specific record is saved, updated or retrieved from the store.
+
+Supported lifecycle hooks are as follows.
+
+- `creating`
+- `created`
+- `updating`
+- `updated`
+- `saving`
+- `saved`
+- `deleting`
+- `deleted`
+
+## Defining Lifecycle Hooks
+
+To define lifecycle hooks, you can define them as a static method with the corresponding lifecycle hook name at Model.
+
+```js
+class User extends Model {
+  static entity = 'users'
+
+  static fields () {
+    /* ... */
+  }
+
+  static saving (model) {
+    // Do something.
+  }
+
+  static deleted (model) {
+    // Do something.
+  }
+}
+```
+
+## Mutation Lifecycle Hook
+
+Mutation lifecycle hooks are called when you mutate data in the store. The corresponding hook name are `creating`, `updating`, `saving`, `deleting`, `created`, `updated`, `deleted` and `saved`.
+
+When in `creating`, `updating` or `saving`, you can modify the record directly to mutate the data to be saved.
+
+```js
+class Post extends Model {
+  static entity = 'posts'
+
+  static fields () {
+    /* ... */
+  }
+
+  static creating (model) {
+    model.published = true
+  }
+}
+```
+
+If you return false from `before` hooks (saving, deleting, updating, creating), that record will not be persisted to the state.
+
+```js
+class Post extends Model {
+  static entity = 'posts'
+
+  static fields () {
+    /* ... */
+  }
+
+  static saving (model) {
+    if (model.doNotModify) {
+      return false
+    }
+  }
+}
+```
+
+## Repository Pinia Hook
+
+For repository actions you can also use pinia if you want to listen to them:
+`delete`, `insert`, `update`, `flush`, `destroy`, `save` and `fresh`
+
+````js
+const userRepo = useRepo(User)
+
+userRepo.piniaStore().$onAction(({
+  name, // name of the action
+  // store, // store instance, same as `someStore`
+  args, // array of parameters passed to the action
+  after, // hook after the action returns or resolves
+  onError, // hook if the action throws or rejects
+}) => {
+  // a shared variable for this specific action call
+  const startTime = Date.now()
+  // this will trigger before an action on `store` is executed
+  console.log(`Start "${name}" with params [${args.join(', ')}].`)
+
+  // this will trigger if the action succeeds and after it has fully run.
+  // it waits for any returned promised
+  after((result) => {
+    console.log(
+      `Finished "${name}" after ${
+        Date.now() - startTime
+      }ms.\nResult: ${result}.`,
+    )
+  })
+
+  // this will trigger if the action throws or returns a promise that rejects
+  onError((error) => {
+    console.warn(
+      `Failed "${name}" after ${Date.now() - startTime}ms.\nError: ${error}.`,
+    )
+  })
+})
+
+````
+
+## Global Lifecycle Hook
+
+For global events you can also use pinia. You can listen to every action:
+`delete`, `insert`, `update`, `flush`, `destroy`, `save` and `fresh`
+
+```js
+pinia.use({ store } => {
+  store.$onAction({'save', data } => {
+      console.log(data)
+  })
+})
+```

--- a/docs/content/2.model/5.pinia-options.md
+++ b/docs/content/2.model/5.pinia-options.md
@@ -58,3 +58,15 @@ class User extends Model {
   }
 }
 ```
+
+## Getting the pinia store instance
+
+You can also get pinia store instance by using `piniaStore`
+
+````js
+const userRepo = useRepo(User)
+
+console.log(userRepo.piniaStore().state.value)
+````
+
+For more details look at [pinia core concepts](https://pinia.vuejs.org/core-concepts/)

--- a/packages/pinia-orm/src/connection/Connection.ts
+++ b/packages/pinia-orm/src/connection/Connection.ts
@@ -36,7 +36,6 @@ export class Connection {
    * Get all existing records.
    */
   get(): Elements {
-    // const connection = this.database.connection
     const newStore = useDataStore(this.model.$entity(), this.model.$piniaOptions())
     const store = newStore()
 

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -28,8 +28,12 @@ export interface ModelOptions {
   mutator?: 'set' | 'get' | 'none'
 }
 
-export interface Hook<M extends Model = Model> {
+export interface BeforeHook<M extends Model = Model> {
   (model: M): void | boolean
+}
+
+export interface AfterHook<M extends Model = Model> {
+  (model: M): void
 }
 
 export class Model {
@@ -346,17 +350,32 @@ export class Model {
   /**
    * Lifecycle hook for before saving
    */
-  static saving = <M extends Model = Model>(model: M): void | boolean | M => model
+  static saving: BeforeHook = () => {}
 
   /**
-   * Lifecycle hook for before saving
+   * Lifecycle hook for before updating
    */
-  static updating = <M extends Model = Model>(model: M): void | boolean | M => model
+  static updating: BeforeHook = () => {}
 
   /**
-   * Lifecycle hook for before saving
+   * Lifecycle hook for before creating
    */
-  static creating = <M extends Model = Model>(model: M): void | boolean | M => model
+  static creating: BeforeHook = () => {}
+
+  /**
+   * Lifecycle hook for before saved
+   */
+  static saved: AfterHook = () => {}
+
+  /**
+   * Lifecycle hook for before updated
+   */
+  static updated: AfterHook = () => {}
+
+  /**
+   * Lifecycle hook for before created
+   */
+  static created: AfterHook = () => {}
 
   /**
    * Mutators to mutate matching fields when instantiating the model.

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -363,19 +363,29 @@ export class Model {
   static creating: BeforeHook = () => {}
 
   /**
-   * Lifecycle hook for before saved
+   * Lifecycle hook for before deleting
+   */
+  static deleting: BeforeHook = () => {}
+
+  /**
+   * Lifecycle hook for after saved
    */
   static saved: AfterHook = () => {}
 
   /**
-   * Lifecycle hook for before updated
+   * Lifecycle hook for after updated
    */
   static updated: AfterHook = () => {}
 
   /**
-   * Lifecycle hook for before created
+   * Lifecycle hook for after created
    */
   static created: AfterHook = () => {}
+
+  /**
+   * Lifecycle hook for after deleted
+   */
+  static deleted: AfterHook = () => {}
 
   /**
    * Mutators to mutate matching fields when instantiating the model.

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -28,6 +28,10 @@ export interface ModelOptions {
   mutator?: 'set' | 'get' | 'none'
 }
 
+export interface Hook<M extends Model = Model> {
+  (model: M): void | boolean
+}
+
 export class Model {
   [s: keyof ModelFields]: any
   /**
@@ -338,6 +342,21 @@ export class Model {
 
     return new MorphMany(model, related.newRawInstance(), id, type, localKey)
   }
+
+  /**
+   * Lifecycle hook for before saving
+   */
+  static saving = <M extends Model = Model>(model: M): void | boolean | M => model
+
+  /**
+   * Lifecycle hook for before saving
+   */
+  static updating = <M extends Model = Model>(model: M): void | boolean | M => model
+
+  /**
+   * Lifecycle hook for before saving
+   */
+  static creating = <M extends Model = Model>(model: M): void | boolean | M => model
 
   /**
    * Mutators to mutate matching fields when instantiating the model.

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -10,7 +10,7 @@ import type { Collection, Element, Elements, Item } from '../data/Data'
 import type { Database } from '../database/Database'
 import { Relation } from '../model/attributes/relations/Relation'
 import { MorphTo } from '../model/attributes/relations/MorphTo'
-import type { AfterHook, Model, ModelOptions } from '../model/Model'
+import type { Model, ModelOptions } from '../model/Model'
 import { Interpreter } from '../interpreter/Interpreter'
 import { Connection } from '../connection/Connection'
 import type {

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -509,6 +509,7 @@ export class Query<M extends Model = Model> {
   saveElements(elements: Elements): void {
     const newData = {} as Elements
     const currentData = this.data()
+    const afterSavingHooks = []
 
     for (const id in elements) {
       const record = elements[id]
@@ -522,10 +523,14 @@ export class Query<M extends Model = Model> {
       if (isSaving === false || isUpdatingOrCreating === false)
         continue
 
+      afterSavingHooks.push(() => model.$self().saved(model))
+      afterSavingHooks.push(() => existing ? model.$self().updated(model) : model.$self().created(model))
       newData[id] = model.$getAttributes()
     }
-    if (Object.keys(newData).length > 0)
+    if (Object.keys(newData).length > 0) {
       this.newConnection().save(newData)
+      afterSavingHooks.forEach(hook => hook())
+    }
   }
 
   /**

--- a/packages/pinia-orm/src/repository/Repository.ts
+++ b/packages/pinia-orm/src/repository/Repository.ts
@@ -1,3 +1,4 @@
+import type { Store } from 'pinia'
 import type { Constructor } from '../types'
 import { assert } from '../support/Utils'
 import type { Collection, Element, Item } from '../data/Data'
@@ -13,6 +14,7 @@ import type {
   WhereSecondaryClosure,
 } from '../query/Options'
 import { useRepo } from '../composables/useRepo'
+import { useDataStore } from '../composables/useDataStore'
 
 export class Repository<M extends Model = Model> {
   /**
@@ -84,6 +86,14 @@ export class Repository<M extends Model = Model> {
     ])
 
     return this.model
+  }
+
+  /**
+   * Return the pinia store used with this model
+   */
+  piniaStore(): Store {
+    const store = useDataStore(this.model.$entity(), this.model.$piniaOptions())
+    return store()
   }
 
   /**

--- a/packages/pinia-orm/tests/feature/hooks/created.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/created.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Model, Num, Str, useRepo } from '../../../src'
+import { assertState } from '../../helpers'
+
+describe('feature/hooks/created', () => {
+  it('does nothing when passing in an empty array', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static created(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const createdMethod = vi.spyOn(User, 'created')
+
+    useRepo(User).save([])
+
+    expect(createdMethod).toBeCalledTimes(0)
+
+    assertState({})
+  })
+
+  it('is able to change values', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static created(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const createdMethod = vi.spyOn(User, 'created')
+    const updatedMethod = vi.spyOn(User, 'updated')
+    const savedMethod = vi.spyOn(User, 'saved')
+
+    useRepo(User).save([
+      { id: 1, name: 'John Doe', age: 30 },
+      { id: 2, name: 'John Doe 2', age: 40 },
+    ])
+
+    expect(createdMethod).toHaveBeenCalledTimes(2)
+    expect(updatedMethod).toHaveBeenCalledTimes(0)
+    expect(savedMethod).toHaveBeenCalledTimes(2)
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+        2: { id: 2, name: 'John Doe 2', age: 40 },
+      },
+    })
+  })
+})

--- a/packages/pinia-orm/tests/feature/hooks/creating.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/creating.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Model, Num, Str, useRepo } from '../../../src'
+import { assertState } from '../../helpers'
+
+describe('feature/hooks/creating', () => {
+  it('does nothing when passing in an empty array', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static creating(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const creatingMethod = vi.spyOn(User, 'creating')
+
+    useRepo(User).save([])
+
+    expect(creatingMethod).toBeCalledTimes(0)
+
+    assertState({})
+  })
+
+  it('is able to change values', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static creating(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const creatingMethod = vi.spyOn(User, 'creating')
+    const updatingMethod = vi.spyOn(User, 'updating')
+    const savingMethod = vi.spyOn(User, 'saving')
+
+    useRepo(User).save([
+      { id: 1, name: 'John Doe', age: 30 },
+      { id: 2, name: 'John Doe 2', age: 40 },
+    ])
+
+    expect(creatingMethod).toHaveBeenCalledTimes(2)
+    expect(updatingMethod).toHaveBeenCalledTimes(0)
+    expect(savingMethod).toHaveBeenCalledTimes(2)
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John', age: 30 },
+        2: { id: 2, name: 'John', age: 40 },
+      },
+    })
+  })
+
+  it('is stopping record to be saved', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static creating(model: Model) {
+        model.name = 'John'
+        return false
+      }
+    }
+
+    const creatingMethod = vi.spyOn(User, 'creating')
+
+    useRepo(User).save({ id: 1, name: 'John Doe', age: 30 })
+
+    expect(creatingMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {},
+    })
+  })
+})

--- a/packages/pinia-orm/tests/feature/hooks/deleted.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/deleted.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Model, Num, Str, useRepo } from '../../../src'
+import {
+  assertState,
+  fillState,
+} from '../../helpers'
+
+describe('feature/hooks/deleted', () => {
+  it('is not triggered when trying to delete a non existing record', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static deleted(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const deletedMethod = vi.spyOn(User, 'deleted')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+      },
+    })
+
+    useRepo(User).destroy(2)
+
+    expect(deletedMethod).toBeCalledTimes(0)
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+      },
+    })
+  })
+
+  it('is being called with destroy', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static deleted() {
+        // Doing deleted stuff
+      }
+    }
+
+    const deletedMethod = vi.spyOn(User, 'deleted')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 10 },
+        2: { id: 2, name: 'John Doe', age: 10 },
+      },
+    })
+
+    useRepo(User).destroy([1,2])
+
+    expect(deletedMethod).toHaveBeenCalledTimes(2)
+
+    assertState({
+      users: {},
+    })
+  })
+
+  it('is being called with delete', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static deleted() {
+        // Doing deleted stuff
+      }
+    }
+
+    const deletedMethod = vi.spyOn(User, 'deleted')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 10 },
+        2: { id: 2, name: 'John Doe', age: 10 },
+      },
+    })
+
+    useRepo(User).where('id', 1).delete()
+
+    expect(deletedMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {
+        2: { id: 2, name: 'John Doe', age: 10 },
+      },
+    })
+  })
+
+})

--- a/packages/pinia-orm/tests/feature/hooks/deleted.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/deleted.spec.ts
@@ -61,7 +61,7 @@ describe('feature/hooks/deleted', () => {
       },
     })
 
-    useRepo(User).destroy([1,2])
+    useRepo(User).destroy([1, 2])
 
     expect(deletedMethod).toHaveBeenCalledTimes(2)
 
@@ -102,5 +102,4 @@ describe('feature/hooks/deleted', () => {
       },
     })
   })
-
 })

--- a/packages/pinia-orm/tests/feature/hooks/deleting.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/deleting.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Model, Num, Str, useRepo } from '../../../src'
+import {
+  assertState,
+  fillState,
+} from '../../helpers'
+
+describe('feature/hooks/deleting', () => {
+  it('can be destroyed', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static deleting(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const deletingMethod = vi.spyOn(User, 'deleting')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+      },
+    })
+
+    useRepo(User).destroy(1)
+
+    expect(deletingMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {},
+    })
+  })
+
+  it('can be deleted', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static deleting(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const deletingMethod = vi.spyOn(User, 'deleting')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 10 },
+        2: { id: 2, name: 'John Doe', age: 10 },
+      },
+    })
+
+    useRepo(User).where('id', 1).delete()
+
+    expect(deletingMethod).toHaveBeenCalledTimes(1)
+
+    assertState({
+      users: {
+        2: { id: 2, name: 'John Doe', age: 10 },
+      },
+    })
+  })
+
+  it('is stopping record being deleted', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static deleting(model: Model) {
+        model.name = 'John'
+        return false
+      }
+    }
+
+    const deletingMethod = vi.spyOn(User, 'deleting')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John', age: 50 },
+      },
+    })
+
+    useRepo(User).destroy(1)
+
+    expect(deletingMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John', age: 50 },
+      },
+    })
+  })
+})

--- a/packages/pinia-orm/tests/feature/hooks/saved.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/saved.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Model, Num, Str, useRepo } from '../../../src'
+import { assertState } from '../../helpers'
+
+describe('feature/hooks/saved', () => {
+  it('does nothing when passing in an empty array', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static saved() {
+        // Doing saved stuff
+      }
+    }
+
+    const savedMethod = vi.spyOn(User, 'saved')
+
+    useRepo(User).save([])
+
+    expect(savedMethod).toBeCalledTimes(0)
+
+    assertState({})
+  })
+
+  it('is being called', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static saved() {
+        // Doing saved stuff
+      }
+    }
+
+    const savedMethod = vi.spyOn(User, 'saved')
+
+    useRepo(User).save({ id: 1, name: 'John Doe', age: 30 })
+
+    expect(savedMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+      },
+    })
+  })
+})

--- a/packages/pinia-orm/tests/feature/hooks/saving.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/saving.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Model, Num, Str, useRepo } from '../../../src'
+import { assertState } from '../../helpers'
+
+describe('feature/hooks/saving', () => {
+  it('does nothing when passing in an empty array', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static saving(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const savingMethod = vi.spyOn(User, 'saving')
+
+    useRepo(User).save([])
+
+    expect(savingMethod).toBeCalledTimes(0)
+
+    assertState({})
+  })
+
+  it('is able to change values', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static saving(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const savingMethod = vi.spyOn(User, 'saving')
+
+    useRepo(User).save({ id: 1, name: 'John Doe', age: 30 })
+
+    expect(savingMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John', age: 30 },
+      },
+    })
+  })
+
+  it('is stopping record to be saved', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static saving(model: Model) {
+        model.name = 'John'
+        return false
+      }
+    }
+
+    const savingMethod = vi.spyOn(User, 'saving')
+
+    useRepo(User).save({ id: 1, name: 'John Doe', age: 30 })
+
+    expect(savingMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {},
+    })
+  })
+})

--- a/packages/pinia-orm/tests/feature/hooks/updated.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/updated.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Model, Num, Str, useRepo } from '../../../src'
+import {
+  assertState,
+  fillState,
+} from '../../helpers'
+
+describe('feature/hooks/updated', () => {
+  it('does nothing when passing in an empty array', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static updated(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const updatedMethod = vi.spyOn(User, 'updated')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+      },
+    })
+
+    useRepo(User).save([])
+
+    expect(updatedMethod).toBeCalledTimes(0)
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+      },
+    })
+  })
+
+  it('is being called', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static updated() {
+        // Doing updated stuff
+      }
+    }
+
+    const createdMethod = vi.spyOn(User, 'created')
+    const updatedMethod = vi.spyOn(User, 'updated')
+    const savedMethod = vi.spyOn(User, 'saved')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 10 },
+        2: { id: 2, name: 'John Doe', age: 10 },
+      },
+    })
+
+    useRepo(User).save([
+      { id: 1, name: 'John Doe', age: 30 },
+      { id: 2, name: 'John Doe 2', age: 40 },
+    ])
+
+    expect(createdMethod).toHaveBeenCalledTimes(0)
+    expect(updatedMethod).toHaveBeenCalledTimes(2)
+    expect(savedMethod).toHaveBeenCalledTimes(2)
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+        2: { id: 2, name: 'John Doe 2', age: 40 },
+      },
+    })
+  })
+})

--- a/packages/pinia-orm/tests/feature/hooks/updating.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/updating.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Model, Num, Str, useRepo } from '../../../src'
+import {
+  assertState,
+  fillState,
+} from '../../helpers'
+
+describe('feature/hooks/updating', () => {
+  it('does nothing when passing in an empty array', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static updating(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const updatingMethod = vi.spyOn(User, 'updating')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+      },
+    })
+
+    useRepo(User).save([])
+
+    expect(updatingMethod).toBeCalledTimes(0)
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+      },
+    })
+  })
+
+  it('is able to change values', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static updating(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    const creatingMethod = vi.spyOn(User, 'creating')
+    const updatingMethod = vi.spyOn(User, 'updating')
+    const savingMethod = vi.spyOn(User, 'saving')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 10 },
+        2: { id: 2, name: 'John Doe', age: 10 },
+      },
+    })
+
+    useRepo(User).save([
+      { id: 1, name: 'John Doe', age: 30 },
+      { id: 2, name: 'John Doe 2', age: 40 },
+    ])
+
+    expect(creatingMethod).toHaveBeenCalledTimes(0)
+    expect(updatingMethod).toHaveBeenCalledTimes(2)
+    expect(savingMethod).toHaveBeenCalledTimes(2)
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John', age: 30 },
+        2: { id: 2, name: 'John', age: 40 },
+      },
+    })
+  })
+
+  it('is stopping record to be saved', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Num(0) id!: number
+      @Str('') name!: string
+      @Num(0) age!: number
+
+      static updating(model: Model) {
+        model.name = 'John'
+        return false
+      }
+    }
+
+    const updatingMethod = vi.spyOn(User, 'updating')
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John', age: 50 },
+      },
+    })
+
+    useRepo(User).save({ id: 1, name: 'John Doe', age: 30 })
+
+    expect(updatingMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John', age: 50 },
+      },
+    })
+  })
+})

--- a/packages/pinia-orm/tests/performance/save_has_many_relation.spec.ts
+++ b/packages/pinia-orm/tests/performance/save_has_many_relation.spec.ts
@@ -21,7 +21,7 @@ describe('performance/save_has_many_relation', () => {
       posts!: Post[]
   }
 
-  it.skip('saves data with has many relation within decent time', () => {
+  it('saves data with has many relation within decent time', () => {
     const userRepo = useRepo(User)
 
     const users = []

--- a/packages/pinia-orm/tests/performance/save_has_many_relation.spec.ts
+++ b/packages/pinia-orm/tests/performance/save_has_many_relation.spec.ts
@@ -21,7 +21,7 @@ describe('performance/save_has_many_relation', () => {
       posts!: Post[]
   }
 
-  it('saves data with has many relation within decent time', () => {
+  it.skip('saves data with has many relation within decent time', () => {
     const userRepo = useRepo(User)
 
     const users = []


### PR DESCRIPTION
## Thoughts

Adding local & global life cycle hooks like retrieved, creating, created, updating, updated, saving, saved, deleting, deleted.

## ToDos

- [x] Creating
- [x] Created
- [x] Updating
- [x] Updated
- [x] Deleting
- [x] Deleted
- [x] ~~Retrieved~~
- [x] Saving
- [x] Saved
- [x] Docs

## Examples

````ts
    class User extends Model {
      static entity = 'users'

      @Num(0) id!: number
      @Str('') name!: string
      @Num(0) age!: number

      static updating(model: Model) {
        model.name = 'John'
      }
    }
````