### PR TITLE
feat(pinia-orm)!: Add casts for attributes & strict types

### DIFF
--- a/packages/pinia-orm/src/index.cjs.ts
+++ b/packages/pinia-orm/src/index.cjs.ts
@@ -8,6 +8,7 @@ import { Database } from './database/Database'
 import { Schema } from './schema/Schema'
 import { Model } from './model/Model'
 import { Mutate } from './model/decorators/Mutate'
+import { Cast } from './model/decorators/Cast'
 import { Attr } from './model/decorators/attributes/types/Attr'
 import { Str } from './model/decorators/attributes/types/Str'
 import { Num } from './model/decorators/attributes/types/Num'
@@ -21,6 +22,7 @@ import { HasManyBy } from './model/decorators/attributes/relations/HasManyBy'
 import { MorphOne } from './model/decorators/attributes/relations/MorphOne'
 import { MorphMany } from './model/decorators/attributes/relations/MorphMany'
 import { Attribute } from './model/attributes/Attribute'
+import { CastAttribute } from './model/casts/CastAttribute'
 import { Type } from './model/attributes/types/Type'
 import { Attr as AttrAttr } from './model/attributes/types/Attr'
 import { String as StringAttr } from './model/attributes/types/String'
@@ -51,6 +53,7 @@ export default {
   Schema,
   Model,
   Mutate,
+  Cast,
   Attr,
   Str,
   Num,
@@ -64,6 +67,7 @@ export default {
   MorphOne,
   MorphMany,
   Attribute,
+  CastAttribute,
   Type,
   AttrAttr,
   StringAttr,

--- a/packages/pinia-orm/src/index.ts
+++ b/packages/pinia-orm/src/index.ts
@@ -8,6 +8,7 @@ import { Database } from './database/Database'
 import { Schema } from './schema/Schema'
 import { Model } from './model/Model'
 import { Attribute } from './model/attributes/Attribute'
+import { CastAttribute } from './model/casts/CastAttribute'
 import { Type } from './model/attributes/types/Type'
 import { Attr as AttrAttr } from './model/attributes/types/Attr'
 import { String as StringAttr } from './model/attributes/types/String'
@@ -50,9 +51,11 @@ export * from './model/decorators/attributes/relations/MorphOne'
 export * from './model/decorators/attributes/relations/MorphTo'
 export * from './model/decorators/attributes/relations/MorphMany'
 export * from './model/decorators/Contracts'
+export * from './model/decorators/Cast'
 export * from './model/decorators/Mutate'
 export * from './model/decorators/NonEnumerable'
 export * from './model/attributes/Attribute'
+export * from './model/casts/CastAttribute'
 export * from './model/attributes/types/Type'
 export { Attr as AttrAttr } from './model/attributes/types/Attr'
 export { String as StringAttr } from './model/attributes/types/String'
@@ -89,6 +92,7 @@ export default {
   Schema,
   Model,
   Attribute,
+  CastAttribute,
   Type,
   AttrAttr,
   StringAttr,

--- a/packages/pinia-orm/src/model/attributes/types/String.ts
+++ b/packages/pinia-orm/src/model/attributes/types/String.ts
@@ -16,12 +16,12 @@ export class String extends Type {
     if (value === undefined)
       return this.value
 
-    if (typeof value === 'string')
-      return value
+    if (value === null)
+      return this.isNullable ? value : `${value}`
 
-    if (value === null && this.isNullable)
-      return value
+    if (typeof value !== 'string')
+      this.throwWarning('string', value)
 
-    return `${value}`
+    return value
   }
 }

--- a/packages/pinia-orm/src/model/attributes/types/Type.ts
+++ b/packages/pinia-orm/src/model/attributes/types/Type.ts
@@ -28,4 +28,11 @@ export abstract class Type extends Attribute {
 
     return this
   }
+
+  /**
+   * Throw warning for wrong type
+   */
+  protected throwWarning(type: string, value: any) {
+    console.warn(['[Pinia ORM]'].concat([`${this.model.$entity()}:`, value, 'is not a', type]).join(' '))
+  }
 }

--- a/packages/pinia-orm/src/model/casts/CastAttribute.ts
+++ b/packages/pinia-orm/src/model/casts/CastAttribute.ts
@@ -1,0 +1,29 @@
+import type { ModelFields } from '../Model'
+
+export interface Casts {
+  [name: string]: () => CastAttribute | string
+}
+
+export abstract class CastAttribute {
+  /**
+   * The model instance.
+   */
+  protected attributes: ModelFields
+
+  /**
+   * Create a new Attribute instance.
+   */
+  constructor(attributes: ModelFields) {
+    this.attributes = attributes
+  }
+
+  /**
+   * Make the value for the attribute.
+   */
+  abstract get(value?: any): any
+
+  /**
+   * Make the value for the attribute.
+   */
+  abstract set(value?: any): any
+}

--- a/packages/pinia-orm/src/model/casts/StringCast.ts
+++ b/packages/pinia-orm/src/model/casts/StringCast.ts
@@ -1,0 +1,22 @@
+import type { ModelFields } from '../Model'
+import { CastAttribute } from './CastAttribute'
+
+export class StringCast extends CastAttribute {
+  /**
+   * Create a new String attribute instance.
+   */
+  constructor(attributes: ModelFields) {
+    super(attributes)
+  }
+
+  get(value?: any): any {
+    return typeof value === 'string' || value === undefined || value === null ? value : `${value}`
+  }
+
+  /**
+   * Make the value for the attribute.
+   */
+  set(value: any): string | null {
+    return this.get(value)
+  }
+}

--- a/packages/pinia-orm/src/model/decorators/Cast.ts
+++ b/packages/pinia-orm/src/model/decorators/Cast.ts
@@ -1,0 +1,12 @@
+import type { CastAttribute } from '../casts/CastAttribute'
+import type { PropertyDecorator } from './Contracts'
+
+/**
+ * Create a cast for an attribute property decorator.
+ */
+export function Cast(to: string | (() => typeof CastAttribute)): PropertyDecorator {
+  return (target, propertyKey) => {
+    const self = target.$self()
+    self.setCast(propertyKey, to)
+  }
+}

--- a/packages/pinia-orm/src/types/index.ts
+++ b/packages/pinia-orm/src/types/index.ts
@@ -3,6 +3,7 @@ export interface Constructor<T> {
 }
 
 export type Mutator<T> = (value: T) => T
+export type Casting<T> = (value: T) => T
 
 export interface MutatorFunctions<T> {
   get?: Mutator<T>

--- a/packages/pinia-orm/tests/feature/relations/has_many_save.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/has_many_save.spec.ts
@@ -32,8 +32,8 @@ describe('feature/relations/has_many_save', () => {
       id: 1,
       name: 'John Doe',
       posts: [
-        { id: 1, userId: 1, title: 100 },
-        { id: 2, userId: 1, title: 200 },
+        { id: 1, userId: 1, title: '100' },
+        { id: 2, userId: 1, title: '200' },
       ],
     })
 

--- a/packages/pinia-orm/tests/feature/relations/morph_one_save_custom_key.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/morph_one_save_custom_key.spec.ts
@@ -14,7 +14,7 @@ describe('feature/relations/morph_one_save_custom_key', () => {
 
       @Num(0) id!: number
       @Str('') url!: string
-      @Str('') imageableId!: number
+      @Num(0) imageableId!: number
       @Str('') imageableType!: string
     }
 
@@ -23,7 +23,7 @@ describe('feature/relations/morph_one_save_custom_key', () => {
 
       static primaryKey = 'userId'
 
-      @Str('') userId!: string
+      @Num(0) userId!: number
       @Str('') name!: string
 
       @MorphOne(() => Image, 'imageableId', 'imageableType')
@@ -44,13 +44,13 @@ describe('feature/relations/morph_one_save_custom_key', () => {
 
     assertState({
       users: {
-        1: { userId: '1', name: 'John Doe' },
+        1: { userId: 1, name: 'John Doe' },
       },
       images: {
         1: {
           id: 1,
           url: '/profile.jpg',
-          imageableId: '1',
+          imageableId: 1,
           imageableType: 'users',
         },
       },
@@ -63,7 +63,7 @@ describe('feature/relations/morph_one_save_custom_key', () => {
 
       @Num(0) id!: number
       @Str('') url!: string
-      @Str('') imageableId!: string
+      @Num(0) imageableId!: number
       @Str('') imageableType!: string
     }
 
@@ -71,7 +71,7 @@ describe('feature/relations/morph_one_save_custom_key', () => {
       static entity = 'users'
 
       @Num(0) id!: number
-      @Str('') userId!: string
+      @Num(0) userId!: number
       @Str('') name!: string
 
       @MorphOne(() => Image, 'imageableId', 'imageableType', 'userId')
@@ -93,13 +93,13 @@ describe('feature/relations/morph_one_save_custom_key', () => {
 
     assertState({
       users: {
-        1: { id: 1, userId: '2', name: 'John Doe' },
+        1: { id: 1, userId: 2, name: 'John Doe' },
       },
       images: {
         1: {
           id: 1,
           url: '/profile.jpg',
-          imageableId: '2',
+          imageableId: 2,
           imageableType: 'users',
         },
       },

--- a/packages/pinia-orm/tests/unit/model/Model_Attrs_String.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Attrs_String.spec.ts
@@ -13,8 +13,8 @@ describe('unit/model/Model_Attrs_String', () => {
 
     expect(new User({}).str).toBe('default')
     expect(new User({ str: 'value' }).str).toBe('value')
-    expect(new User({ str: 1 }).str).toBe('1')
-    expect(new User({ str: true }).str).toBe('true')
+    expect(new User({ str: 1 }).str).toBe(1)
+    expect(new User({ str: true }).str).toBe(true)
     expect(new User({ str: null }).str).toBe('null')
   })
 
@@ -28,8 +28,8 @@ describe('unit/model/Model_Attrs_String', () => {
 
     expect(new User({}).str).toBe(null)
     expect(new User({ str: 'value' }).str).toBe('value')
-    expect(new User({ str: 1 }).str).toBe('1')
-    expect(new User({ str: true }).str).toBe('true')
+    expect(new User({ str: 1 }).str).toBe(1)
+    expect(new User({ str: true }).str).toBe(true)
     expect(new User({ str: null }).str).toBe(null)
   })
 })

--- a/packages/pinia-orm/tests/unit/model/Model_Casts_String.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Casts_String.spec.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { Attr, Cast, Model, Str, useRepo } from '../../../src'
+import { assertState } from '../../helpers'
+
+describe('unit/model/Model_Casts', () => {
+  beforeEach(() => {
+    Model.clearRegistries()
+  })
+  it('should cast to string', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Str('') name!: string
+
+      static casts() {
+        return {
+          name: 'string',
+        }
+      }
+    }
+
+    expect(new User({ name: 123 }).name).toBe('123')
+  })
+
+  it('should cast with decorator', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Cast('string')
+      @Str('test')
+        name!: string
+    }
+
+    expect(new User({ name: true }).name).toBe('true')
+    expect(new User({ name: 1 }).name).toBe('1')
+    expect(new User({ name: null }).name).toBe('null')
+    expect(new User().name).toBe('test')
+  })
+
+  it('accepts `null` when the `nullable` option is set', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Cast('string')
+      @Str(null, { nullable: true })
+        str!: string | null
+    }
+
+    expect(new User().str).toBe(null)
+    expect(new User({ str: 'value' }).str).toBe('value')
+    expect(new User({ str: 1 }).str).toBe('1')
+    expect(new User({ str: true }).str).toBe('true')
+    expect(new User({ str: null }).str).toBe(null)
+  })
+
+  it('should cast before saved into store', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Attr(0) id!: number
+      @Attr('') name!: string
+
+      static casts() {
+        return {
+          name: 'string',
+        }
+      }
+    }
+
+    const userRepo = useRepo(User)
+    userRepo.save({
+      id: 1,
+      name: 1234,
+    })
+
+    assertState({
+      users: {
+        1: { id: 1, name: '1234' },
+      },
+    })
+
+    expect(userRepo.find(1)?.name).toBe('1234')
+  })
+})


### PR DESCRIPTION
## Thoughts

It's over with auto casting ;-) .... after reading and thinking i decided to introduce strict types. So for now if you have defined a `string` field it will throw a console warning if the type is not correct (I will also make an option i think to throw an error instead of an warning.

But the good news....casting is coming back in form of standard and custom casts:
examples:
````ts
    class User extends Model {
      static entity = 'users'

      @Str('') name!: string

      static casts() {
        return {
          name: 'string',
        }
      }
````

or with decorator

````ts
    class User extends Model {
      static entity = 'users'

      @Cast('string')
      @Str('test')
        name!: string
    }
````

## ToDos:
- [x] String Cast & Test
- [ ] Boolean Cast & Test
- [ ] Number Cast & Test
- [x] Cast Decorator
- [ ] Docs

---

BREAKING CHANGES: No more auto casting. if still want to have the same behaviour you have to use `casts`
