### PR TITLE
feat(pinia-orm): add query methods

### DIFF
--- a/docs/content/4.repository/2.retrieving-data.md
+++ b/docs/content/4.repository/2.retrieving-data.md
@@ -173,3 +173,26 @@ useRepo(User).has('comments', '>', 2).get()
 // Retrieve all posts that have less than or exactly 2 comments.
 useRepo(User).has('comments', '<=', 2).get()
 ```
+
+If you need even more power, you may use the `whereHas` method to put "where" conditions on your `has` queries. This method allows you to add customized constraints to a relationship constraint, such as checking the content of a comment.
+
+```js
+// Retrieve all posts that have comment from user_id 1.
+useRepo(Post).whereHas('comments', (query) => {
+  query.where('user_id', 1)
+}).get()
+```
+
+To retrieve records depending on the absence of the relationship, use the `doesntHave` and `whereDoesntHave` methods. These methods will work the same as `has` and `whereHas` but with the opposite result.
+
+```js
+// Retrieve all posts that doesn't have comments.
+useRepo(Post).doesntHave('comments').get()
+
+// Retrieve all posts that doesn't have comment with user_id of 1.
+useRepo(Post).whereDoesntHave('comments', (query) => {
+  query.where('user_id', 1)
+}).get()
+```
+
+You have also the corresponding or conditions `orHas`, `orDoesntHave`, `orWhereHas` and `orWhereDoesntHave`.

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -292,13 +292,14 @@ export class Query<M extends Model = Model> {
    * Get where closure for relations
    */
   protected getFieldWhereForRelations(relation: string, callback: EagerLoadConstraint = () => {}, operator?: string | number, count?: number): WherePrimaryClosure {
-    const modelIdsByRelation = this.newQuery(this.model.$entity()).with(relation, callback).get().filter(
-      model => compareWithOperator(
+    const modelIdsByRelation = this.newQuery(this.model.$entity()).with(relation, callback).get()
+      .filter(model => compareWithOperator(
         model[relation] ? model[relation].length : throwError(['Relation', relation, 'not found in model: ', model.$entity()]),
         typeof operator === 'number' ? operator : count ?? 1,
         typeof operator === 'number' || count === undefined ? '>=' : operator,
-      ),
-    ).map(model => model.$getIndexId())
+      ))
+      .map(model => model.$getIndexId())
+
     return model => modelIdsByRelation.includes(model.$getIndexId())
   }
 
@@ -701,9 +702,6 @@ export class Query<M extends Model = Model> {
     const [afterHooks, removeIds] = this.dispatchDeleteHooks(models)
     const checkedIds = this.getIndexIdsFromCollection(models).filter(id => !removeIds.includes(id))
 
-    if (isEmpty(checkedIds))
-      return []
-
     this.commit('destroy', checkedIds)
     afterHooks.forEach(hook => hook())
 
@@ -721,9 +719,6 @@ export class Query<M extends Model = Model> {
 
     const [afterHooks, removeIds] = this.dispatchDeleteHooks(models)
     const ids = this.getIndexIdsFromCollection(models).filter(id => !removeIds.includes(id))
-
-    if (isEmpty(ids))
-      return []
 
     this.commit('delete', ids)
     afterHooks.forEach(hook => hook())

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -158,18 +158,73 @@ export class Query<M extends Model = Model> {
   }
 
   /**
-   * Set where constraint based on relationship existence.
+   * Add a "where has" clause to the query.
+   */
+  whereHas(relation: string, callback: EagerLoadConstraint = () => {}, operator?: string | number, count?: number): this {
+    this.where(this.getFieldWhereForRelations(relation, callback, operator, count))
+
+    return this
+  }
+
+  /**
+   * Add an "or where has" clause to the query.
+   */
+  orWhereHas(relation: string, callback: EagerLoadConstraint = () => {}, operator?: string | number, count?: number): this {
+    this.orWhere(this.getFieldWhereForRelations(relation, callback, operator, count))
+
+    return this
+  }
+
+  /**
+   * Add a "has" clause to the query.
    */
   has(relation: string, operator?: string | number, count?: number): this {
-    const modelIdsByRelation = this.newQuery(this.model.$entity()).with(relation).get().filter(
-      model => compareWithOperator(
-        model[relation] ? model[relation].length : throwError(['Relation', relation, 'not found in model: ', model.$entity()]),
-        typeof operator === 'number' ? operator : count ?? 1,
-        typeof operator === 'number' || count === undefined ? '>=' : operator,
-      ),
-    ).map(model => model.$getIndexId())
-    const field: WherePrimaryClosure = model => modelIdsByRelation.includes(model.$getIndexId())
-    this.where(field)
+    this.where(this.getFieldWhereForRelations(relation, () => {}, operator, count))
+
+    return this
+  }
+
+  /**
+   * Add an "or has" clause to the query.
+   */
+  orHas(relation: string, operator?: string | number, count?: number): this {
+    this.orWhere(this.getFieldWhereForRelations(relation, () => {}, operator, count))
+
+    return this
+  }
+
+  /**
+   * Add a "doesn't have" clause to the query.
+   */
+  doesntHave(relation: string): this {
+    this.where(this.getFieldWhereForRelations(relation, () => {}, '=', 0))
+
+    return this
+  }
+
+  /**
+   * Add a "doesn't have" clause to the query.
+   */
+  orDoesntHave(relation: string): this {
+    this.orWhere(this.getFieldWhereForRelations(relation, () => {}, '=', 0))
+
+    return this
+  }
+
+  /**
+   * Add a "where doesn't have" clause to the query.
+   */
+  whereDoesntHave(relation: string, callback: EagerLoadConstraint = () => {}): this {
+    this.where(this.getFieldWhereForRelations(relation, callback, '=', 0))
+
+    return this
+  }
+
+  /**
+   * Add an "or where doesn't have" clause to the query.
+   */
+  orWhereDoesntHave(relation: string, callback: EagerLoadConstraint = () => {}): this {
+    this.orWhere(this.getFieldWhereForRelations(relation, callback, '=', 0))
 
     return this
   }
@@ -231,6 +286,20 @@ export class Query<M extends Model = Model> {
     })
 
     return this
+  }
+
+  /**
+   * Get where closure for relations
+   */
+  protected getFieldWhereForRelations(relation: string, callback: EagerLoadConstraint = () => {}, operator?: string | number, count?: number): WherePrimaryClosure {
+    const modelIdsByRelation = this.newQuery(this.model.$entity()).with(relation, callback).get().filter(
+      model => compareWithOperator(
+        model[relation] ? model[relation].length : throwError(['Relation', relation, 'not found in model: ', model.$entity()]),
+        typeof operator === 'number' ? operator : count ?? 1,
+        typeof operator === 'number' || count === undefined ? '>=' : operator,
+      ),
+    ).map(model => model.$getIndexId())
+    return model => modelIdsByRelation.includes(model.$getIndexId())
   }
 
   /**

--- a/packages/pinia-orm/src/repository/Repository.ts
+++ b/packages/pinia-orm/src/repository/Repository.ts
@@ -133,10 +133,59 @@ export class Repository<M extends Model = Model> {
   }
 
   /**
+   * Add a "where has" clause to the query.
+   */
+  whereHas(relation: string, callback: EagerLoadConstraint = () => {}, operator?: string | number, count?: number): Query<M> {
+    return this.query().whereHas(relation, callback, operator, count)
+  }
+
+  /**
+   * Add an "or where has" clause to the query.
+   */
+  orWhereHas(relation: string, callback: EagerLoadConstraint = () => {}, operator?: string | number, count?: number): Query<M> {
+    return this.query().orWhereHas(relation, callback, operator, count)
+  }
+
+  /**
    * Add a "has" clause to the query.
    */
   has(relation: string, operator?: string | number, count?: number): Query<M> {
     return this.query().has(relation, operator, count)
+  }
+
+  /**
+   * Add an "or has" clause to the query.
+   */
+  orHas(relation: string, operator?: string | number, count?: number): Query<M> {
+    return this.query().orHas(relation, operator, count)
+  }
+
+  /**
+   * Add a "doesn't have" clause to the query.
+   */
+  doesntHave(relation: string): Query<M> {
+    return this.query().doesntHave(relation)
+  }
+
+  /**
+   * Add a "doesn't have" clause to the query.
+   */
+  orDoesntHave(relation: string): Query<M> {
+    return this.query().orDoesntHave(relation)
+  }
+
+  /**
+   * Add a "where doesn't have" clause to the query.
+   */
+  whereDoesntHave(relation: string, callback: EagerLoadConstraint = () => {}): Query<M> {
+    return this.query().whereDoesntHave(relation, callback)
+  }
+
+  /**
+   * Add an "or where doesn't have" clause to the query.
+   */
+  orWhereDoesntHave(relation: string, callback: EagerLoadConstraint = () => {}): Query<M> {
+    return this.query().orWhereDoesntHave(relation, callback)
   }
 
   /**

--- a/packages/pinia-orm/tests/unit/model/Model_Casts_Boolean.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Casts_Boolean.spec.ts
@@ -34,8 +34,10 @@ describe('unit/model/Model_Casts_Boolean', () => {
 
     expect(new User({ isPublished: true }).isPublished).toBe(true)
     expect(new User({ isPublished: 0 }).isPublished).toBe(false)
+    expect(new User({ isPublished: '1' }).isPublished).toBe(true)
     expect(new User({ isPublished: null }).isPublished).toBe(false)
     expect(new User({ isPublished: '' }).isPublished).toBe(false)
+    expect(new User({ isPublished: 'tt12' }).isPublished).toBe(true)
     expect(new User({ isPublished: {} }).isPublished).toBe(false)
     expect(new User().isPublished).toBe(true)
   })

--- a/packages/pinia-orm/tests/unit/model/Model_Casts_Number.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Casts_Number.spec.ts
@@ -33,6 +33,7 @@ describe('unit/model/Model_Casts_Number', () => {
     }
 
     expect(new User({ count: true }).count).toBe(1)
+    expect(new User({ count: false }).count).toBe(0)
     expect(new User({ count: 1 }).count).toBe(1)
     expect(new User({ count: '1.43' }).count).toBe(1.43)
     expect(new User().count).toBe(0)

--- a/packages/pinia-orm/tests/unit/support/Utils_Compare_With_Operator.spec.ts
+++ b/packages/pinia-orm/tests/unit/support/Utils_Compare_With_Operator.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { compareWithOperator } from '../../../src/support/Utils'
+
+describe('unit/support/Utils_Compare_With_Operator', () => {
+  it('can compare with string operator', () => {
+    expect(compareWithOperator(1, 2, '<')).toBe(true)
+    expect(compareWithOperator(1, 2, '<=')).toBe(true)
+    expect(compareWithOperator(1, 2, '>')).toBe(false)
+    expect(compareWithOperator(1, 2, '>=')).toBe(false)
+    expect(compareWithOperator(1, 2, '!=')).toBe(true)
+    expect(compareWithOperator(1, 2)).toBe(false)
+    expect(compareWithOperator(1, 1)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Thoughts
Adding "whereHas", "orHas", "orWhereHas", "doesntHave", "orDoesntHave", "whereDoesntHave" and "orWhereDoesntHave" to query

## ToDos
- [x] tests
- [x] docs
- [x] functions

