### PR TITLE
feat(pinia-orm)!: Make fields default nullable

### DIFF
--- a/docs/content/1.guide/2.model/1.getting-started.md
+++ b/docs/content/1.guide/2.model/1.getting-started.md
@@ -90,12 +90,12 @@ class User extends Model {
 
 This attribute will ensure a given value is cast as a string. For example, if  `name` receives a value of `false` or `null`, it will become `'false'` or `'null'`.
 
-This attribute may also have `null` as a default value. However, to prevent casting, you will want to chain `nullable()` to ensure the value can be set appropriately.
+This attribute has `null` as a default value. However, if you want to get warning if a value should not be nullable you can set `notNullable()`.
 
 ```js
 {
   ...
-  name: this.string(null).nullable()
+  name: this.string(null).notNullable()
 }
 ```
 
@@ -124,12 +124,12 @@ class User extends Model {
 
 This attribute will ensure a given value is cast as a number. For example, if `id` receives a value of `false`, it will become `0`, `null` will become `0`, `'123'` will become `123`, and so on.
 
-This attribute may also have `null` as a default value. However, to prevent casting, you will want to chain `nullable()` to ensure the value can be set appropriately.
+This attribute has `null` as a default value. However, if you want to get warning if a value should not be nullable you can set `notNullable()`.
 
 ```js
 {
   ...
-  name: this.number(null).nullable()
+  name: this.number(null).notNullable()
 }
 ```
 
@@ -158,12 +158,12 @@ class User extends Model {
 
 This attribute will ensure a given value is cast as a boolean. Any truthy or falsy value will be cast accordingly. For example, if `active` receives a value of `0` or `null`, it will become `false`. Likewise, if it receives a value of `1` or `'yes'` (non-empty string) it will become `true`.
 
-This attribute may also have `null` as a default value. However, to prevent casting, you will want to chain `nullable()` to ensure the value can be set appropriately.
+This attribute has `null` as a default value. However, if you want to get warning if a value should not be nullable you can set `notNullable()`.
 
 ```js
 {
   ...
-  active: this.boolean(null).nullable()
+  active: this.boolean(null).notNullable()
 }
 ```
 

--- a/docs/content/1.guide/2.model/4.decorators.md
+++ b/docs/content/1.guide/2.model/4.decorators.md
@@ -91,7 +91,7 @@ export class User extends Model {
   @Str('')
   name!: string
 
-  @Str(null, { nullable: true })
+  @Str('', { notNullable: true })
   address!: string | null
 }
 ```
@@ -110,7 +110,7 @@ export class User extends Model {
   @Num(0)
   count!: number
 
-  @Num(null, { nullable: true })
+  @Num(0, { notNullable: true })
   roleId!: number | null
 }
 ```
@@ -129,7 +129,7 @@ export class User extends Model {
   @Bool(false)
   active!: boolean
 
-  @Bool(null, { nullable: true })
+  @Bool(false, { notNullable: true })
   visible!: boolean | null
 }
 ```

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -589,12 +589,12 @@ export class Model {
   protected $fillField(key: string, attr: Attribute, value: any): any {
     if (value !== undefined) {
       return attr instanceof MorphTo
-        ? attr.make(value, this[attr.getType()])
-        : attr.make(value)
+        ? attr.setKey(key).make(value, this[attr.getType()])
+        : attr.setKey(key).make(value)
     }
 
     if (this[key] === undefined)
-      return attr.make()
+      return attr.setKey(key).make()
   }
 
   /**

--- a/packages/pinia-orm/src/model/attributes/Attribute.ts
+++ b/packages/pinia-orm/src/model/attributes/Attribute.ts
@@ -7,10 +7,24 @@ export abstract class Attribute {
   protected model: Model
 
   /**
+   * The field name
+   */
+  protected key: string
+
+  /**
    * Create a new Attribute instance.
    */
   constructor(model: Model) {
     this.model = model
+    this.key = ''
+  }
+
+  /**
+   * Set the key name of the field
+   */
+  setKey(key: string): this {
+    this.key = key
+    return this
   }
 
   /**

--- a/packages/pinia-orm/src/model/attributes/types/Boolean.ts
+++ b/packages/pinia-orm/src/model/attributes/types/Boolean.ts
@@ -13,6 +13,6 @@ export class Boolean extends Type {
    * Make the value for the attribute.
    */
   make(value: any): boolean | null {
-    return this.makeReturn<boolean | null>('boolean', value, false)
+    return this.makeReturn<boolean | null>('boolean', value)
   }
 }

--- a/packages/pinia-orm/src/model/attributes/types/Number.ts
+++ b/packages/pinia-orm/src/model/attributes/types/Number.ts
@@ -13,6 +13,6 @@ export class Number extends Type {
    * Make the value for the attribute.
    */
   make(value: any): number | null {
-    return this.makeReturn<number | null>('number', value, 0)
+    return this.makeReturn<number | null>('number', value)
   }
 }

--- a/packages/pinia-orm/src/model/attributes/types/String.ts
+++ b/packages/pinia-orm/src/model/attributes/types/String.ts
@@ -13,6 +13,6 @@ export class String extends Type {
    * Make the value for the attribute.
    */
   make(value: any): string | null {
-    return this.makeReturn<string | null>('string', value, `${value}`)
+    return this.makeReturn<string | null>('string', value)
   }
 }

--- a/packages/pinia-orm/src/model/attributes/types/Type.ts
+++ b/packages/pinia-orm/src/model/attributes/types/Type.ts
@@ -10,7 +10,7 @@ export abstract class Type extends Attribute {
   /**
    * Whether the attribute accepts `null` value or not.
    */
-  protected isNullable = false
+  protected isNullable = true
 
   /**
    * Create a new Type attribute instance.
@@ -23,21 +23,25 @@ export abstract class Type extends Attribute {
   /**
    * Set the nullable option to true.
    */
-  nullable(): this {
-    this.isNullable = true
+  notNullable(): this {
+    this.isNullable = false
 
     return this
   }
 
-  protected makeReturn<T>(type: string, value: any, nullableValue = value): T {
+  protected makeReturn<T>(type: string, value: any): T {
     if (value === undefined)
       return this.value
 
-    if (value === null)
-      return this.isNullable ? value : nullableValue
+    if (value === null) {
+      if (!this.isNullable)
+        this.throwWarning(['is set as non nullable!'])
+
+      return value
+    }
 
     if (typeof value !== type)
-      this.throwWarning(type, value)
+      this.throwWarning([value, 'is not a', type])
 
     return value
   }
@@ -45,8 +49,8 @@ export abstract class Type extends Attribute {
   /**
    * Throw warning for wrong type
    */
-  protected throwWarning(type: string, value: any) {
+  protected throwWarning(message: string[]) {
     // eslint-disable-next-line no-console
-    console.warn(['[Pinia ORM]'].concat([`${this.model.$entity()}:`, value, 'is not a', type]).join(' '))
+    console.warn(['[Pinia ORM]'].concat([`Field ${this.model.$entity()}:${this.key} - `, ...message]).join(' '))
   }
 }

--- a/packages/pinia-orm/src/model/decorators/Contracts.ts
+++ b/packages/pinia-orm/src/model/decorators/Contracts.ts
@@ -3,5 +3,5 @@ import type { Model } from '../Model'
 export type PropertyDecorator = (target: Model, propertyKey: string) => void
 
 export interface TypeOptions {
-  nullable?: boolean
+  notNullable?: boolean
 }

--- a/packages/pinia-orm/src/model/decorators/attributes/types/Bool.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/types/Bool.ts
@@ -13,8 +13,8 @@ export function Bool(
     self.setRegistry(propertyKey, () => {
       const attr = self.boolean(value)
 
-      if (options.nullable)
-        attr.nullable()
+      if (options.notNullable)
+        attr.notNullable()
 
       return attr
     })

--- a/packages/pinia-orm/src/model/decorators/attributes/types/Num.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/types/Num.ts
@@ -13,8 +13,8 @@ export function Num(
     self.setRegistry(propertyKey, () => {
       const attr = self.number(value)
 
-      if (options.nullable)
-        attr.nullable()
+      if (options.notNullable)
+        attr.notNullable()
 
       return attr
     })

--- a/packages/pinia-orm/src/model/decorators/attributes/types/Str.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/types/Str.ts
@@ -13,8 +13,8 @@ export function Str(
     self.setRegistry(propertyKey, () => {
       const attr = self.string(value)
 
-      if (options.nullable)
-        attr.nullable()
+      if (options.notNullable)
+        attr.notNullable()
 
       return attr
     })

--- a/packages/pinia-orm/src/schema/Schema.ts
+++ b/packages/pinia-orm/src/schema/Schema.ts
@@ -121,7 +121,7 @@ export class Schema {
       // uid field.
       for (const key in uidFields) {
         if (isNullish(record[key]))
-          record[key] = uidFields[key].make(record[key])
+          record[key] = uidFields[key].setKey(key).make(record[key])
       }
 
       // Finally, obtain the index id, attach it to the current record at the

--- a/packages/pinia-orm/tests/unit/model/Model_Attrs_Boolean.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Attrs_Boolean.spec.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { Model } from '../../../src'
 import { Bool } from '../../../src/decorators'
 
 describe('unit/model/Model_Attrs_Boolean', () => {
-  it('casts the value to `Boolean` when instantiating the model', () => {
+  it('casts not the value to `Boolean` when instantiating the model', () => {
     class User extends Model {
       static entity = 'users'
 
@@ -19,16 +19,18 @@ describe('unit/model/Model_Attrs_Boolean', () => {
     expect(new User({ bool: 0 }).bool).toBe(0)
     expect(new User({ bool: 1 }).bool).toBe(1)
     expect(new User({ bool: true }).bool).toBe(true)
-    expect(new User({ bool: null }).bool).toBe(false)
+    expect(new User({ bool: null }).bool).toBe(null)
   })
 
-  it('accepts `null` when the `nullable` option is set', () => {
+  it('accepts `null` when the `notNullable` option is set', () => {
     class User extends Model {
       static entity = 'users'
 
-      @Bool(null, { nullable: true })
+      @Bool(null, { notNullable: true })
         bool!: boolean | null
     }
+
+    const logger = vi.spyOn(console, 'warn')
 
     expect(new User({}).bool).toBe(null)
     expect(new User({ bool: '' }).bool).toBe('')
@@ -38,5 +40,6 @@ describe('unit/model/Model_Attrs_Boolean', () => {
     expect(new User({ bool: 1 }).bool).toBe(1)
     expect(new User({ bool: true }).bool).toBe(true)
     expect(new User({ bool: null }).bool).toBe(null)
+    expect(logger).toBeCalledTimes(6)
   })
 })

--- a/packages/pinia-orm/tests/unit/model/Model_Attrs_Number.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Attrs_Number.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { Model } from '../../../src'
 import { Num } from '../../../src/decorators'
@@ -17,16 +17,18 @@ describe('unit/model/Model_Attrs_Number', () => {
     expect(new User({ num: '2' }).num).toBe('2')
     expect(new User({ num: true }).num).toBe(true)
     expect(new User({ num: false }).num).toBe(false)
-    expect(new User({ num: null }).num).toBe(0)
+    expect(new User({ num: null }).num).toBe(null)
   })
 
-  it('accepts `null` when the `nullable` option is set', () => {
+  it('accepts `null` when the `notNullable` option is set', () => {
     class User extends Model {
       static entity = 'users'
 
-      @Num(null, { nullable: true })
+      @Num(null, { notNullable: true })
         num!: number | null
     }
+
+    const logger = vi.spyOn(console, 'warn')
 
     expect(new User({}).num).toBe(null)
     expect(new User({ num: 1 }).num).toBe(1)
@@ -34,5 +36,6 @@ describe('unit/model/Model_Attrs_Number', () => {
     expect(new User({ num: true }).num).toBe(true)
     expect(new User({ num: false }).num).toBe(false)
     expect(new User({ num: null }).num).toBe(null)
+    expect(logger).toBeCalledTimes(4)
   })
 })

--- a/packages/pinia-orm/tests/unit/model/Model_Attrs_String.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Attrs_String.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { Model } from '../../../src'
 import { Str } from '../../../src/decorators'
@@ -16,21 +16,24 @@ describe('unit/model/Model_Attrs_String', () => {
     expect(new User({ str: 'value' }).str).toBe('value')
     expect(new User({ str: 1 }).str).toBe(1)
     expect(new User({ str: true }).str).toBe(true)
-    expect(new User({ str: null }).str).toBe('null')
+    expect(new User({ str: null }).str).toBe(null)
   })
 
-  it('accepts `null` when the `nullable` option is set', () => {
+  it('accepts `null` when the `notNullable` option is set', () => {
     class User extends Model {
       static entity = 'users'
 
-      @Str(null, { nullable: true })
+      @Str(null, { notNullable: true })
         str!: string | null
     }
+
+    const logger = vi.spyOn(console, 'warn')
 
     expect(new User({}).str).toBe(null)
     expect(new User({ str: 'value' }).str).toBe('value')
     expect(new User({ str: 1 }).str).toBe(1)
     expect(new User({ str: true }).str).toBe(true)
     expect(new User({ str: null }).str).toBe(null)
+    expect(logger).toBeCalledTimes(3)
   })
 })

--- a/packages/pinia-orm/tests/unit/model/Model_Casts_Boolean.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Casts_Boolean.spec.ts
@@ -37,19 +37,19 @@ describe('unit/model/Model_Casts_Boolean', () => {
     expect(new User({ isPublished: true }, { mutator: 'get' }).isPublished).toBe(true)
     expect(new User({ isPublished: 0 }, { mutator: 'get' }).isPublished).toBe(false)
     expect(new User({ isPublished: '1' }, { mutator: 'get' }).isPublished).toBe(true)
-    expect(new User({ isPublished: null }, { mutator: 'get' }).isPublished).toBe(false)
+    expect(new User({ isPublished: null }, { mutator: 'get' }).isPublished).toBe(null)
     expect(new User({ isPublished: '' }, { mutator: 'get' }).isPublished).toBe(false)
     expect(new User({ isPublished: 'tt12' }, { mutator: 'get' }).isPublished).toBe(true)
     expect(new User({ isPublished: {} }, { mutator: 'get' }).isPublished).toBe(false)
     expect(new User({ mutator: 'get' }).isPublished).toBe(true)
   })
 
-  it('accepts "null" when the "nullable" option is set', () => {
+  it('accepts "null" when the "notNullable" option is set', () => {
     class User extends Model {
       static entity = 'users'
 
       @Cast(() => BooleanCast)
-      @Bool(null, { nullable: true })
+      @Bool(null, { notNullable: true })
         isPublished!: boolean | null
     }
 

--- a/packages/pinia-orm/tests/unit/model/Model_Casts_Number.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Casts_Number.spec.ts
@@ -41,12 +41,12 @@ describe('unit/model/Model_Casts_Number', () => {
     expect(new User({ mutator: 'get' }).count).toBe(0)
   })
 
-  it('accepts null when the nullable option is set', () => {
+  it('throws warning with null when the notnotNullable option is set', () => {
     class User extends Model {
       static entity = 'users'
 
       @Cast(() => NumberCast)
-      @Num(null, { nullable: true })
+      @Num(null, { notnotNullable: true })
         count!: number | null
     }
 

--- a/packages/pinia-orm/tests/unit/model/Model_Casts_String.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Casts_String.spec.ts
@@ -36,16 +36,16 @@ describe('unit/model/Model_Casts_String', () => {
 
     expect(new User({ name: true }, { mutator: 'get' }).name).toBe('true')
     expect(new User({ name: 1 }, { mutator: 'get' }).name).toBe('1')
-    expect(new User({ name: null }, { mutator: 'get' }).name).toBe('null')
+    expect(new User({ name: null }, { mutator: 'get' }).name).toBe(null)
     expect(new User({ mutator: 'get' }).name).toBe('test')
   })
 
-  it('accepts `null` when the `nullable` option is set', () => {
+  it('accepts `null` when the `notNullable` option is set', () => {
     class User extends Model {
       static entity = 'users'
 
       @Cast(() => StringCast)
-      @Str(null, { nullable: true })
+      @Str(null, { notNullable: true })
         str!: string | null
     }
 

--- a/packages/pinia-orm/tests/unit/model/Model_Sanitize.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Sanitize.spec.ts
@@ -11,7 +11,7 @@ describe('unit/model/Model_Sanitize', () => {
   class User extends Model {
     static entity = 'users'
 
-    @Num(null, { nullable: true }) id!: number
+    @Num(null, { notNullable: true }) id!: number
     @Str('Unknown') name!: string
     @Num(0) age!: number
 


### PR DESCRIPTION
## Related

vuex-orm/vuex-orm-next#95

## Thoughts

It's a good idea to make fields per default null and throw a warning if they are set as `notNullable`

BREAKING CHANGES: Removed `nullable` and added `notNullable`. Fields are per default now null.