### PR TITLE
docs: move to `declare` as typescript standard and add a new page

### DIFF
--- a/docs/content/1.guide/1.getting-started/1.quick-start.md
+++ b/docs/content/1.guide/1.getting-started/1.quick-start.md
@@ -31,18 +31,6 @@ description: ''
   ```
   ::
 
-::alert{type="info"}
-#### **Vite Integration**
-
-Make sure to disable `useDefineForClassFields` in `tsconfig.json` when using `vite >= 2.5.0`. See [this issue](https://github.com/vitejs/vite/issues/4636) for more details.
-
-```json
-...
-"useDefineForClassFields": false,
-...
-```
-::
-
   ### Adding the plugin to your pinia store
 
   ::code-group
@@ -92,9 +80,9 @@ Make sure to disable `useDefineForClassFields` in `tsconfig.json` when using `vi
       }
     }
     // For typescript support of the field include also the next lines
-    id!: string
-    name!: string
-    email!: string
+    declare id: string
+    declare name: string
+    declare email: string
   }
   ```
   ```ts{}[Decorator Method]
@@ -107,9 +95,9 @@ Make sure to disable `useDefineForClassFields` in `tsconfig.json` when using `vi
     // entity is a required property for all models.
     static entity = 'users'
   
-    @Uid() id!: string
-    @Str('') name!: string
-    @Str('') email!: string
+    @Uid() declare id: string
+    @Str('') declare name: string
+    @Str('') declare email: string
   }
   ```
   ::
@@ -140,12 +128,12 @@ Make sure to disable `useDefineForClassFields` in `tsconfig.json` when using `vi
       }
     }
     
-    id!: string
-    userId!: string | null
-    title!: string
-    body!: string
-    published!: boolean
-    author!: User | null
+    declare id: string
+    declare userId: string | null
+    declare title: string
+    declare body: string
+    declare published: boolean
+    declare author: User | null
   }
   ```
   ```ts{}[Decorator Method]
@@ -158,12 +146,12 @@ Make sure to disable `useDefineForClassFields` in `tsconfig.json` when using `vi
   export default class Post extends Model {
     static entity = 'posts'
   
-    @Uid() id!: string
-    @Attr(null) userId!: string | null
-    @Str('') title!: string
-    @Str('') body!: string
-    @Bool(false) published!: boolean
-    @BelongsTo(() => User, 'userId') author!: User | null
+    @Uid() declare id: string
+    @Attr(null) declare userId: string | null
+    @Str('') declare title: string
+    @Str('') declare body: string
+    @Bool(false) declare published: boolean
+    @BelongsTo(() => User, 'userId') declare author: User | null
   ```
   ::
 

--- a/docs/content/1.guide/1.getting-started/3.typescript.md
+++ b/docs/content/1.guide/1.getting-started/3.typescript.md
@@ -1,0 +1,93 @@
+---
+title: Typescript
+description: ''
+---
+
+There are diffrent ways to write the classes and having typescript types. I want to show you here the diffrent approches.
+
+## Decorators with declare (recommanded)
+
+::alert{type="info"}
+The tsconfig
+```json
+...
+"useDefineForClassFields": true,
+"experimentalDecorators": true,
+...
+```
+::
+
+This is pretty new if you are a vuex-orm user. If you are a vuex-orm-next user than you are already used to it.
+
+````ts
+import { Model } from 'pinia-orm'
+import { Attr, Cast, Uid } form 'pinia-orm/dist/decorators'
+import { ArrayCast } from 'pinia-orm/dist/casts'
+
+class User extends Model {
+  static entity = 'users'
+
+  @Uid() declare id: string
+  @Cast(() => ArrayCast) @Attr('{}') declare meta: Record<string, any>
+}
+````
+
+For more information about using `declare` read this [ticket](https://github.com/CodeDredd/pinia-orm/issues/148) 
+
+## Without declare
+
+### With decorators
+
+````ts
+import { Model } from 'pinia-orm'
+import { Attr, Cast, Uid } form 'pinia-orm/dist/decorators'
+import { ArrayCast } from 'pinia-orm/dist/casts'
+
+class User extends Model {
+  static entity = 'users'
+
+  @Uid() id!: string
+  @Cast(() => ArrayCast) @Attr('{}') meta!: Record<string, any>
+}
+````
+
+::alert{type="info"}
+#### **Vite Integration**
+
+Make sure to disable `useDefineForClassFields` in `tsconfig.json` when using `vite >= 2.5.0`. See [this issue](https://github.com/vitejs/vite/issues/4636) for more details.
+
+```json
+...
+"useDefineForClassFields": false,
+...
+```
+::
+
+### without decorators (used way from vuex-orm)
+
+
+
+````ts
+import { Model } from 'pinia-orm'
+import { ArrayCast } from 'pinia-orm/dist/casts'
+
+class User extends Model {
+  static entity = 'users'
+
+  static fields() {
+    return {
+      id: this.uid(),
+      meta: this.attr('{}')
+    }
+  }
+
+  static casts() {
+    return {
+      meta: ArrayCast,
+    }
+  }
+
+  id!: number
+  meta!: Record<string, any>
+}
+````

--- a/docs/content/1.guide/1.getting-started/3.typescript.md
+++ b/docs/content/1.guide/1.getting-started/3.typescript.md
@@ -11,7 +11,7 @@ There are diffrent ways to write the classes and having typescript types. I want
 The tsconfig
 ```json
 ...
-"useDefineForClassFields": true,
+"useDefineForClassFields": true,  // Default true if target is "ES2022" or "ESNext"
 "experimentalDecorators": true,
 ...
 ```

--- a/docs/content/1.guide/2.model/2.accessors.md
+++ b/docs/content/1.guide/2.model/2.accessors.md
@@ -58,7 +58,7 @@ import { Attr, Model } from 'pinia-orm'
 class User extends Model {
   static entity = 'users'
 
-  @Attr('') name!: string
+  @Attr('') declare name: string
 
   static mutators() {
     return {
@@ -84,8 +84,8 @@ import { getActivePinia } from 'pinia';
 class User extends Model {
   static entity = 'users'
 
-  @Attr(0) id!: number
-  @Attr('') name!: string
+  @Attr(0) declare id: number
+  @Attr('') declare name: string
 
   static mutators() {
     return {

--- a/docs/content/1.guide/2.model/3.casts.md
+++ b/docs/content/1.guide/2.model/3.casts.md
@@ -54,8 +54,7 @@ class User extends Model {
   static entity = 'users'
 
   @Cast(() => ArrayCast)
-  @Attr('{}')
-    meta!: Record<string, any>
+  @Attr('{}') declare meta: Record<string, any>
 }
 
 console.log(new User({ meta: '{"name":"John", "age":30, "car":null}' }).meta)
@@ -84,7 +83,7 @@ class CustomCast extends CastAttribute {
 class User extends Model {
   static entity = 'users'
 
-  @Attr('{}') name!: string
+  @Attr('{}') declare name: string
 
   static casts() {
     return {
@@ -112,8 +111,7 @@ class CustomCast extends CastAttribute {
 class User extends Model {
   static entity = 'users'
 
-  @Cast(() => CustomCast)
-  @Attr('test') name!: string
+  @Cast(() => CustomCast) @Attr('test') declare name: string
 }
 
 console.log(new User({ name: 'John' }).name) // 'string John'
@@ -142,7 +140,7 @@ class CustomCast extends CastAttribute {
 class User extends Model {
   static entity = 'users'
 
-  @Attr('{}') name!: string
+  @Attr('{}') declare name: string
 
   static casts() {
     return {

--- a/docs/content/1.guide/2.model/4.decorators.md
+++ b/docs/content/1.guide/2.model/4.decorators.md
@@ -19,14 +19,9 @@ import Post from '@/models/Post'
 class User extends Model {
   static entity = 'users'
 
-  @Attr(null)
-  id!: number | null
-
-  @Str('')
-  name!: string
-
-  @HasMany(() => Post, 'userId')
-  posts!: Post[]
+  @Attr(null) declare id: number | null
+  @Str('') declare name: string
+  @HasMany(() => Post, 'userId') declare posts: Post[]
 }
 ```
 
@@ -47,9 +42,9 @@ class User extends Model {
     }
   }
 
-  id!: number | null
-  name!: string
-  posts!: Post[]
+  declare id: number | null
+  declare name: string
+  declare posts: Post[]
 }
 ```
 
@@ -66,14 +61,9 @@ import { Attr } from 'pinia-orm/dist/decorators'
 export class User extends Model {
   static entity = 'users'
 
-  @Attr(null)
-  id!: number | null
-
-  @Attr('John Doe')
-  name!: string
-
-  @Attr(false)
-  active!: boolean
+  @Attr(null) declare id: number | null
+  @Attr('John Doe') declare name: string
+  @Attr(false) declare active: boolean
 }
 ```
 
@@ -88,11 +78,8 @@ import { Attr, Str } from 'pinia-orm/dist/decorators'
 export class User extends Model {
   static entity = 'users'
 
-  @Str('')
-  name!: string
-
-  @Str('', { notNullable: true })
-  address!: string | null
+  @Str('') declare name: string
+  @Str('', { notNullable: true }) declare address: string | null
 }
 ```
 
@@ -107,11 +94,9 @@ import { Num } from 'pinia-orm/dist/decorators'
 export class User extends Model {
   static entity = 'users'
 
-  @Num(0)
-  count!: number
+  @Num(0) declare count: number
 
-  @Num(0, { notNullable: true })
-  roleId!: number | null
+  @Num(0, { notNullable: true }) declare roleId: number | null
 }
 ```
 
@@ -126,11 +111,8 @@ import { Bool } from 'pinia-orm/dist/decorators'
 export class User extends Model {
   static entity = 'users'
 
-  @Bool(false)
-  active!: boolean
-
-  @Bool(false, { notNullable: true })
-  visible!: boolean | null
+  @Bool(false) declare active: boolean
+  @Bool(false, { notNullable: true }) declare visible: boolean | null
 }
 ```
 
@@ -145,8 +127,7 @@ import { Uid } from 'pinia-orm/dist/decorators'
 class User extends Model {
   static entity = 'users'
 
-  @Uid()
-  id!: string
+  @Uid() declare id: string
 }
 ```
 
@@ -161,9 +142,7 @@ import { Attr, Mutate } from 'pinia-orm/dist/decorators'
 class User extends Model {
   static entity = 'users'
 
-  @Mutate((value: any) => value.toUpperCase())
-  @Attr('')
-    name!: string
+  @Mutate((value: any) => value.toUpperCase()) @Attr('') declare name: string
 }
 
 console.log(new User({ name: 'john doe' }).name) // 'JOHN DOE'
@@ -181,9 +160,7 @@ import { StringCast } from 'pinia-orm/casts'
 class User extends Model {
   static entity = 'users'
 
-  @Cast(() => StringCast)
-  @Attr('')
-    name!: string
+  @Cast(() => StringCast) @Attr('') declare name: string
 }
 
 console.log(new User({ name: 1 }).name) // '1'
@@ -205,8 +182,7 @@ import Phone from '@/models/Phone'
 class User extends Model {
   static entity = 'users'
 
-  @HasOne(() => Phone, 'userId')
-  phone: Phone | null
+  @HasOne(() => Phone, 'userId') declare phone: Phone | null
 }
 ```
 
@@ -222,11 +198,8 @@ import User from '@/models/User'
 class Post extends Model {
   static entity = 'posts'
 
-  @Attr(null)
-  userId!: number | null
-
-  @BelongsTo(() => User, 'userId')
-  user!: User | null
+  @Attr(null) declare userId: number | null
+  @BelongsTo(() => User, 'userId') declare user: User | null
 }
 ```
 
@@ -242,8 +215,7 @@ import Post from '@/models/Post'
 class User extends Model {
   static entity = 'users'
 
-  @HasMany(() => Post, 'userId')
-  posts!: Post[]
+  @HasMany(() => Post, 'userId') declare posts: Post[]
 }
 ```
 
@@ -259,11 +231,8 @@ import Node from '@/models/Node'
 class Cluster extends Model {
   static entity = 'clusters'
 
-  @Attr(null)
-  nodeIds!: number[]
-
-  @HasManyBy(() => Node, 'nodesId')
-  nodes!: Node[]
+  @Attr(null) declare nodeIds: number[]
+  @HasManyBy(() => Node, 'nodesId') declare nodes: Node[]
 }
 ```
 
@@ -279,8 +248,7 @@ import Role from '@/models/Role'
 class User extends Model {
   static entity = 'users'
 
-  @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id')
-  roles!: Role[]
+  @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id') declare roles: Role[]
 }
 ```
 
@@ -296,8 +264,7 @@ import Image from '@/models/Image'
 class User extends Model {
   static entity = 'users'
 
-  @MorphOne(() => Image, 'imageableId', 'imageableType')
-  image!: Image | null
+  @MorphOne(() => Image, 'imageableId', 'imageableType') declare image: Image | null
 }
 ```
 
@@ -314,14 +281,9 @@ import Post from '@/models/Post'
 class Image extends Model {
   static entity = 'images'
 
-  @Attr(null)
-  imageableId!: number | null
-
-  @Attr(null)
-  imageableType!: string | null
-
-  @MorphTo(() => [User, Post], 'imageableId', 'imageableType')
-  imageable!: User | Post | null
+  @Attr(null) declare imageableId: number | null
+  @Attr(null) declare imageableType: string | null
+  @MorphTo(() => [User, Post], 'imageableId', 'imageableType') declare imageable: User | Post | null
 }
 ```
 
@@ -335,7 +297,7 @@ import { MorphMany } from 'pinia-orm/dist/decorators'
 import Comment from '@/models/Comment'
 class Video extends Model {
   static entity = 'videos'
-  @MorphMany(() => Comment, 'commentableId', 'commentableType')
-  comments!: Comment[]
+
+  @MorphMany(() => Comment, 'commentableId', 'commentableType') declare comments: Comment[]
 }
 ```

--- a/docs/content/1.guide/2.model/6.pinia-options.md
+++ b/docs/content/1.guide/2.model/6.pinia-options.md
@@ -19,11 +19,8 @@ import Post from '@/models/Post'
 class User extends Model {
   static entity = 'users'
 
-  @Attr(null)
-  id!: number | null
-
-  @Str('')
-  name!: string
+  @Attr(null) declare id: number | null
+  @Str('') declare name: string
   
   static piniaOptions = {
       persist: true
@@ -43,11 +40,8 @@ import Post from '@/models/Post'
 class User extends Model {
   static entity = 'users'
 
-  @Attr(null)
-  id!: number | null
-
-  @Str('')
-  name!: string
+  @Attr(null) declare id: number | null
+  @Str('') declare name: string
   
   static piniaOptions = {
       actions: {

--- a/docs/content/2.api/2.model/1.fields-attributes/attr.md
+++ b/docs/content/2.api/2.model/1.fields-attributes/attr.md
@@ -29,8 +29,8 @@ import { Attr } from 'pinia-orm/dist/decorators'
 class User extends Model {
   static entity = 'users'
   
-  @Attr(null) id!: number | null
-  @Attr('') name!: string
+  @Attr(null) declare id: number | null
+  @Attr('') declare name: string
 }
 ````
 

--- a/docs/content/2.api/2.model/1.fields-attributes/boolean.md
+++ b/docs/content/2.api/2.model/1.fields-attributes/boolean.md
@@ -29,8 +29,8 @@ import { Bool, Num } from 'pinia-orm/dist/decorators'
 class User extends Model {
   static entity = 'users'
   
-  @Num(0) id!: number
-  @Bool(false) published!: boolean
+  @Num(0) declare id: number
+  @Bool(false) declare published: boolean
 }
 ````
 

--- a/docs/content/2.api/2.model/1.fields-attributes/number.md
+++ b/docs/content/2.api/2.model/1.fields-attributes/number.md
@@ -28,7 +28,7 @@ import { Num } from 'pinia-orm/dist/decorators'
 class User extends Model {
   static entity = 'users'
   
-  @Num(0) id!: number
+  @Num(0) declare id: number
 }
 ````
 

--- a/docs/content/2.api/2.model/1.fields-attributes/string.md
+++ b/docs/content/2.api/2.model/1.fields-attributes/string.md
@@ -29,8 +29,8 @@ import { Num, Str } from 'pinia-orm/dist/decorators'
 class User extends Model {
   static entity = 'users'
   
-  @Num(0) id!: number
-  @Str('') name!: string
+  @Num(0) declare id: number
+  @Str('') declare name: string
 }
 ````
 

--- a/docs/content/2.api/2.model/1.fields-attributes/uid.md
+++ b/docs/content/2.api/2.model/1.fields-attributes/uid.md
@@ -28,7 +28,7 @@ import { Uid } from 'pinia-orm/dist/decorators'
 class User extends Model {
   static entity = 'users'
   
-  @Uid() id!: string
+  @Uid() declare id: string
 }
 ````
 

--- a/docs/content/2.api/2.model/2.fields-relations/belongs-to-many.md
+++ b/docs/content/2.api/2.model/2.fields-relations/belongs-to-many.md
@@ -33,8 +33,8 @@ import RoleUser from './RoleUser'
 class User extends Model {
   static entity = 'users'
   
-  @Attr(null) id!: number | null
-  @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id') roles!: Role[]
+  @Attr(null) declare id: number | null
+  @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id') declare roles: Role[]
 }
 ````
 

--- a/docs/content/2.api/2.model/2.fields-relations/belongs-to.md
+++ b/docs/content/2.api/2.model/2.fields-relations/belongs-to.md
@@ -33,10 +33,10 @@ import User from './User'
 class User extends Model {
   static entity = 'users'
   
-  @Attr(null) id!: number | null
-  @Attr(null) userId!: number | null
-  @Str('') number!: string
-  @BelongsTo(() => User, 'userId') user!: User
+  @Attr(null) declare id: number | null
+  @Attr(null) declare userId: number | null
+  @Str('') declare number: string
+  @BelongsTo(() => User, 'userId') declare user: User
 }
 ````
 

--- a/docs/content/2.api/2.model/2.fields-relations/has-many-by.md
+++ b/docs/content/2.api/2.model/2.fields-relations/has-many-by.md
@@ -33,10 +33,10 @@ import Comment from './Comment'
 class Post extends Model {
   static entity = 'posts'
   
-  @Attr(null) id!: number | null
-  @Attr([]) postIds!: number[]
-  @Str('') title!: string
-  @HasManyBy(() => Comment, 'postIds') comments!: Comment[]
+  @Attr(null) declare id: number | null
+  @Attr([]) declare postIds: number[]
+  @Str('') declare title: string
+  @HasManyBy(() => Comment, 'postIds') declare comments: Comment[]
 }
 ````
 

--- a/docs/content/2.api/2.model/2.fields-relations/has-many.md
+++ b/docs/content/2.api/2.model/2.fields-relations/has-many.md
@@ -32,9 +32,9 @@ import Comment from './Comment'
 class Post extends Model {
   static entity = 'posts'
   
-  @Attr(null) id!: number | null
-  @Str('') title!: string
-  @HasMany(() => Comment, 'postId') comments!: Comment[]
+  @Attr(null) declare id: number | null
+  @Str('') declare title: string
+  @HasMany(() => Comment, 'postId') declare comments: Comment[]
 }
 ````
 

--- a/docs/content/2.api/2.model/2.fields-relations/has-one.md
+++ b/docs/content/2.api/2.model/2.fields-relations/has-one.md
@@ -32,9 +32,9 @@ import Phone from './Phone'
 class User extends Model {
   static entity = 'users'
   
-  @Attr(null) id!: number | null
-  @Str('') name!: string
-  @HasOne(() => Phone, 'userId') phone!: Phone
+  @Attr(null) declare id: number | null
+  @Str('') declare name: string
+  @HasOne(() => Phone, 'userId') declare phone: Phone
 }
 ````
 

--- a/docs/content/2.api/2.model/2.fields-relations/morph-many.md
+++ b/docs/content/2.api/2.model/2.fields-relations/morph-many.md
@@ -32,9 +32,9 @@ import Image from './Image'
 class User extends Model {
   static entity = 'users'
   
-  @Attr(null) id!: number | null
-  @Str('') name!: string
-  @MorphMany(() => Image, 'imageableId', 'imageableType') images!: Image[]
+  @Attr(null) declare id: number | null
+  @Str('') declare name: string
+  @MorphMany(() => Image, 'imageableId', 'imageableType') declare images: Image[]
 }
 ````
 

--- a/docs/content/2.api/2.model/2.fields-relations/morph-one.md
+++ b/docs/content/2.api/2.model/2.fields-relations/morph-one.md
@@ -32,9 +32,9 @@ import Image from './Image'
 class User extends Model {
   static entity = 'users'
   
-  @Attr(null) id!: number | null
-  @Str('') name!: string
-  @MorphOne(() => Image, 'imageableId', 'imageableType') image!: Image
+  @Attr(null) declare id: number | null
+  @Str('') declare name: string
+  @MorphOne(() => Image, 'imageableId', 'imageableType') declare image: Image
 }
 ````
 

--- a/docs/content/2.api/2.model/2.fields-relations/morph-to.md
+++ b/docs/content/2.api/2.model/2.fields-relations/morph-to.md
@@ -40,11 +40,11 @@ import Post from './Post'
 class User extends Model {
   static entity = 'users'
   
-  @Num(0) id!: number
-  @Str('') url!: string
-  @Num(0) id!: imageableId
-  @Str('') url!: imageableType
-  @MorphTo(() => [User, Post], 'imageableId', 'imageableType') imageable!: Post[] | User[]
+  @Num(0) declare id: number
+  @Str('') declare url: string
+  @Num(0) declare imageableId: number
+  @Str('') declare imageableType: string
+  @MorphTo(() => [User, Post], 'imageableId', 'imageableType') declare imageable: Post[] | User[]
 }
 ````
 

--- a/docs/content/2.api/2.model/3.casts.md
+++ b/docs/content/2.api/2.model/3.casts.md
@@ -101,7 +101,7 @@ class User extends Model {
 
 ## With Decorator
 
-````js[User.ts]
+````ts[User.ts]
 import { Model } from 'pinia-orm'
 import { Attr, Cast } from 'pinia-orm/dist/decorators'
 import { ArrayCast } from 'pinia-orm/casts'
@@ -109,9 +109,7 @@ import { ArrayCast } from 'pinia-orm/casts'
 class User extends Model {
   static entity = 'users'
 
-  @Cast(() => ArrayCast)
-  @Attr('{}')
-    meta!: Record<string, any>
+  @Cast(() => ArrayCast) @Attr('{}') declare meta: Record<string, any>
 }
 ````
 

--- a/docs/content/2.api/2.model/3.mutators.md
+++ b/docs/content/2.api/2.model/3.mutators.md
@@ -33,16 +33,14 @@ class User extends Model {
 
 ## With Decorator
 
-````js[User.ts]
+````ts[User.ts]
 import { Model } from 'pinia-orm'
 import { Attr, Mutate } from 'pinia-orm/dist/decorators'
 
 class User extends Model {
   static entity = 'users'
 
-  @Mutate((value: any) => value.toUpperCase())
-  @Str('')
-    name!: string
+  @Mutate((value: any) => value.toUpperCase()) @Str('') declare name: string
 }
 ````
 

--- a/docs/theme.config.ts
+++ b/docs/theme.config.ts
@@ -5,7 +5,6 @@ export default defineTheme({
   description: 'The Pinia plugin to enable Object-Relational Mapping access to the Pinia Store.',
   layout: 'docs',
   url: 'https://pinia-orm.codedredd.de',
-  debug: false,
   socials: {
     twitter: '@_GregorBecker',
     github: 'codedredd/pinia-orm'

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -530,9 +530,9 @@
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
 "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
-  integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz#aba35c48a38d3fd84b37e66c9c0423f9744f9774"
+  integrity sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -600,9 +600,9 @@
     untyped "^0.4.4"
 
 "@nuxt-themes/docus@npm:@nuxt-themes/docus-edge@latest":
-  version "3.0.0-60e7c1f"
-  resolved "https://registry.yarnpkg.com/@nuxt-themes/docus-edge/-/docus-edge-3.0.0-60e7c1f.tgz#bdf461a6d8e311c4b137d3909a4bb10e9fd9b8a8"
-  integrity sha512-XKx/IL5JlPr7fzHUhQbUKy2AHNWfnuEZmnxDqO1oDPpb9e+VLLM+1vJ1Dh3qjjZDgJocYt5Ha/cbcKXBi8Z8jw==
+  version "3.0.0-dd1d705"
+  resolved "https://registry.yarnpkg.com/@nuxt-themes/docus-edge/-/docus-edge-3.0.0-dd1d705.tgz#f49dc624ac65ece189f38b39e878122f515e77c0"
+  integrity sha512-KZemtj7r5TMrNgtmUA5iXd8mqVSLugPN742rE/gC9NDYbOqnwyGLIM1oeevnP4WJiHGIy760xlsYc9a6iTaVfA==
   dependencies:
     "@iconify/vue" "^3.2.1"
     "@nuxt-themes/config" "npm:@nuxt-themes/config-edge@latest"
@@ -637,9 +637,9 @@
     untyped "^0.4.4"
 
 "@nuxt/content@npm:@nuxt/content-edge@latest":
-  version "2.1.0-27667349.b409f18"
-  resolved "https://registry.yarnpkg.com/@nuxt/content-edge/-/content-edge-2.1.0-27667349.b409f18.tgz#4c5891ebf3e4e3fc486e1f4fb45f20685f4c8bf1"
-  integrity sha512-KF8+UDOFO5H+1UKS7HA85lyRhxLARfWKBd1zo1AM4jOm0iz0nDPV7RTzwc5V0DU0dDDLf/67BxHkVzwMNYGD/g==
+  version "2.1.0-27681784.61c3032"
+  resolved "https://registry.yarnpkg.com/@nuxt/content-edge/-/content-edge-2.1.0-27681784.61c3032.tgz#fa0a05c409e193d3f19190e2cfeccfa07178f535"
+  integrity sha512-NxS1frJ/4b+thBmSbtG+ZJbBUtlQuDf6pNMHu6uU2fpuN0nNBQjxz7Oazj2EPxvXuBb0uLPeqx+uaOKz2lotKg==
   dependencies:
     "@nuxt/kit" "^3.0.0-rc.6"
     consola "^2.15.3"
@@ -683,7 +683,7 @@
   resolved "https://registry.yarnpkg.com/@nuxt/devalue/-/devalue-2.0.0.tgz#c7bd7e9a516514e612d5d2e511ffc399e0eac322"
   integrity sha512-YBI/6o2EBz02tdEJRBK8xkt3zvOFOWlLBf7WKYGBsSYSRtjjgrqPe2skp6VLLmKx5WbHHDNcW+6oACaurxGzeA==
 
-"@nuxt/kit@3.0.0-rc.6", "@nuxt/kit@^3.0.0-rc.3", "@nuxt/kit@^3.0.0-rc.4", "@nuxt/kit@^3.0.0-rc.5", "@nuxt/kit@^3.0.0-rc.6":
+"@nuxt/kit@3.0.0-rc.6":
   version "3.0.0-rc.6"
   resolved "https://registry.yarnpkg.com/@nuxt/kit/-/kit-3.0.0-rc.6.tgz#b59c10639cb591bdc5a63164fb352b344230a065"
   integrity sha512-+lxSd6dSWlAzMXfGOPcY4856xnMF1Ck1rycFUZ+K2QYiDXphq/fiW2eMaWLVvqgPyL2Box2WzVDZJ6C5ceptcw==
@@ -706,6 +706,30 @@
     unctx "^1.1.4"
     unimport "^0.4.5"
     untyped "^0.4.4"
+
+"@nuxt/kit@^3.0.0-rc.3", "@nuxt/kit@^3.0.0-rc.4", "@nuxt/kit@^3.0.0-rc.5", "@nuxt/kit@^3.0.0-rc.6":
+  version "3.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@nuxt/kit/-/kit-3.0.0-rc.8.tgz#e65e739e986abf5bfe99fa44a3bf44bacc66a35a"
+  integrity sha512-FkbO7DPkJxuLqeiWEMUI8OWXaQ4qzmreIjslIPrc9buYdB9nbJqVVzQRicxcKzF09R7VwpJTiG6onIZq6iGuDQ==
+  dependencies:
+    "@nuxt/schema" "3.0.0-rc.8"
+    c12 "^0.2.9"
+    consola "^2.15.3"
+    defu "^6.0.0"
+    globby "^13.1.2"
+    hash-sum "^2.0.0"
+    ignore "^5.2.0"
+    jiti "^1.14.0"
+    knitwork "^0.1.2"
+    lodash.template "^4.5.0"
+    mlly "^0.5.12"
+    pathe "^0.3.4"
+    pkg-types "^0.3.3"
+    scule "^0.3.2"
+    semver "^7.3.7"
+    unctx "^2.0.1"
+    unimport "^0.6.7"
+    untyped "^0.4.5"
 
 "@nuxt/kit@npm:@nuxt/kit-edge@3.0.0-rc.6-27667279.0b22079":
   version "3.0.0-rc.6-27667279.0b22079"
@@ -745,21 +769,21 @@
     postcss-url "^10.1.1"
     semver "^7.3.4"
 
-"@nuxt/schema@^3.0.0-rc.6":
-  version "3.0.0-rc.6"
-  resolved "https://registry.yarnpkg.com/@nuxt/schema/-/schema-3.0.0-rc.6.tgz#47baab10792057c799cd60ab2570d4fa20d65e1d"
-  integrity sha512-BcD5YtWRhn+jU2DlzuI1TeITFeOt5x6qm2KeaU/d5jzJ0oZDzmZwKsAimLtRbHwyU6/kKa+zFbK6pp5obm1XLg==
+"@nuxt/schema@3.0.0-rc.8", "@nuxt/schema@^3.0.0-rc.6":
+  version "3.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@nuxt/schema/-/schema-3.0.0-rc.8.tgz#d8fab177f4b58fcdb83bd530a887d3b4acea90b7"
+  integrity sha512-ODl9cmjH8fupvXjzITIvYT4OzapNvLrvWq9QUUgLhgv3Uxl2iX2J03oLj2aCQgfhte4mJhgHsBrtXvDLF/1GwA==
   dependencies:
-    c12 "^0.2.8"
+    c12 "^0.2.9"
     create-require "^1.1.1"
     defu "^6.0.0"
     jiti "^1.14.0"
-    pathe "^0.3.2"
+    pathe "^0.3.4"
     postcss-import-resolver "^2.0.0"
-    scule "^0.2.1"
+    scule "^0.3.2"
     std-env "^3.1.1"
     ufo "^0.8.5"
-    unimport "^0.4.5"
+    unimport "^0.6.7"
 
 "@nuxt/schema@npm:@nuxt/schema-edge@3.0.0-rc.6-27667279.0b22079":
   version "3.0.0-rc.6-27667279.0b22079"
@@ -890,9 +914,9 @@
     pathe "^0.3.0"
 
 "@nuxtjs/design-tokens@npm:@nuxtjs/design-tokens-edge@latest":
-  version "0.0.1-27658684.ecf71f4"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/design-tokens-edge/-/design-tokens-edge-0.0.1-27658684.ecf71f4.tgz#d58bda7baeca228b8433b9908c848ba47ea536fa"
-  integrity sha512-jThZ47fibWjCzIMtniYacuh+bAh99zuLAGU/+oeiWI5+88OWyDqxpAwtiyVQbsizgsVyYhbq2lUHSn+rGFym/w==
+  version "0.0.1-27671200.58cd49e"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/design-tokens-edge/-/design-tokens-edge-0.0.1-27671200.58cd49e.tgz#328f5c22d936bc49fab64b1e0cba6740ddab8d41"
+  integrity sha512-gejoXOdowbkuou1a1j26VHtSfeGSgKG3Vlc5tf+CqvB1OtKjGF+rx1P6NF7xIHhNh5PoilcZDHyb0+w1YN+wbQ==
   dependencies:
     "@nuxt/kit" "^3.0.0-rc.6"
     browser-style-dictionary "^3.1.1-browser.1"
@@ -930,54 +954,54 @@
     remark-github "^11.2.4"
 
 "@octokit/auth-token@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-3.0.0.tgz#6f22c5fc56445c496628488ba6810131558fa4a9"
-  integrity sha512-MDNFUBcJIptB9At7HiV7VCvU3NcL4GnfCQaP8C5lrxWrRPMJBnemYtehaKSOlaM7AYxeRyj9etenu8LVpSpVaQ==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-3.0.1.tgz#88bc2baf5d706cb258474e722a720a8365dff2ec"
+  integrity sha512-/USkK4cioY209wXRpund6HZzHo9GmjakpV9ycOkpMcMxMk7QVcVFVyCMtzvXYiHsB2crgDgrtNYSELYFBXhhaA==
   dependencies:
-    "@octokit/types" "^6.0.3"
+    "@octokit/types" "^7.0.0"
 
 "@octokit/core@^4.0.0":
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-4.0.4.tgz#335d9b377691e3264ce57a9e5a1f6cda783e5838"
-  integrity sha512-sUpR/hc4Gc7K34o60bWC7WUH6Q7T6ftZ2dUmepSyJr9PRF76/qqkWjE2SOEzCqLA5W83SaISymwKtxks+96hPQ==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-4.0.5.tgz#589e68c0a35d2afdcd41dafceab072c2fbc6ab5f"
+  integrity sha512-4R3HeHTYVHCfzSAi0C6pbGXV8UDI5Rk+k3G7kLVNckswN9mvpOzW9oENfjfH3nEmzg8y3AmKmzs8Sg6pLCeOCA==
   dependencies:
     "@octokit/auth-token" "^3.0.0"
     "@octokit/graphql" "^5.0.0"
     "@octokit/request" "^6.0.0"
     "@octokit/request-error" "^3.0.0"
-    "@octokit/types" "^6.0.3"
+    "@octokit/types" "^7.0.0"
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/endpoint@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-7.0.0.tgz#be758a1236d68d6bbb505e686dd50881c327a519"
-  integrity sha512-Kz/mIkOTjs9rV50hf/JK9pIDl4aGwAtT8pry6Rpy+hVXkAPhXanNQRxMoq6AeRgDCZR6t/A1zKniY2V1YhrzlQ==
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-7.0.1.tgz#cb0d03e62e8762f3c80e52b025179de81899a823"
+  integrity sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==
   dependencies:
-    "@octokit/types" "^6.0.3"
+    "@octokit/types" "^7.0.0"
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/graphql@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-5.0.0.tgz#2cc6eb3bf8e0278656df1a7d0ca0d7591599e3b3"
-  integrity sha512-1ZZ8tX4lUEcLPvHagfIVu5S2xpHYXAmgN0+95eAOPoaVPzCfUXJtA5vASafcpWcO86ze0Pzn30TAx72aB2aguQ==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-5.0.1.tgz#a06982514ad131fb6fbb9da968653b2233fade9b"
+  integrity sha512-sxmnewSwAixkP1TrLdE6yRG53eEhHhDTYUykUwdV9x8f91WcbhunIHk9x1PZLALdBZKRPUO2HRcm4kezZ79HoA==
   dependencies:
     "@octokit/request" "^6.0.0"
-    "@octokit/types" "^6.0.3"
+    "@octokit/types" "^7.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^12.11.0":
-  version "12.11.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-12.11.0.tgz#da5638d64f2b919bca89ce6602d059f1b52d3ef0"
-  integrity sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==
+"@octokit/openapi-types@^13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-13.4.0.tgz#06fe8fda93bf21bdd397fe7ef8805249efda6c06"
+  integrity sha512-2mVzW0X1+HDO3jF80/+QFZNzJiTefELKbhMu6yaBYbp/1gSMkVDm4rT472gJljTokWUlXaaE63m7WrWENhMDLw==
 
-"@octokit/plugin-paginate-rest@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-3.1.0.tgz#86f8be759ce2d6d7c879a31490fd2f7410b731f0"
-  integrity sha512-+cfc40pMzWcLkoDcLb1KXqjX0jTGYXjKuQdFQDc6UAknISJHnZTiBqld6HDwRJvD4DsouDKrWXNbNV0lE/3AXA==
+"@octokit/plugin-paginate-rest@^4.0.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.1.0.tgz#670ac9ac369448c69a2371bfcd7e2b37d95534f2"
+  integrity sha512-2O5K5fpajYG5g62wjzHR7/cWYaCA88CextAW3vFP+yoIHD0KEdlVMHfM5/i5LyV+JMmqiYW7w5qfg46FR+McNw==
   dependencies:
-    "@octokit/types" "^6.41.0"
+    "@octokit/types" "^7.1.1"
 
 "@octokit/plugin-request-log@^1.0.4":
   version "1.0.4"
@@ -985,50 +1009,50 @@
   integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
 
 "@octokit/plugin-rest-endpoint-methods@^6.0.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.2.0.tgz#c06359d2f94436f8c67d345093cb02dedd31d974"
-  integrity sha512-PZ+yfkbZAuRUtqu6Y191/V3eM0KBPx+Yq7nh+ONPdpm3EX4pd5UnK2y2XgO/0AtNum5a4aJCDjqsDuUZ2hWRXw==
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.3.0.tgz#81549334ce020169b84bd4a7fa2577e9d725d829"
+  integrity sha512-qEu2wn6E7hqluZwIEUnDxWROvKjov3zMIAi4H4d7cmKWNMeBprEXZzJe8pE5eStUYC1ysGhD0B7L6IeG1Rfb+g==
   dependencies:
-    "@octokit/types" "^6.41.0"
+    "@octokit/types" "^7.0.0"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-3.0.0.tgz#f527d178f115a3b62d76ce4804dd5bdbc0270a81"
-  integrity sha512-WBtpzm9lR8z4IHIMtOqr6XwfkGvMOOILNLxsWvDwtzm/n7f5AWuqJTXQXdDtOvPfTDrH4TPhEvW2qMlR4JFA2w==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-3.0.1.tgz#3fd747913c06ab2195e52004a521889dadb4b295"
+  integrity sha512-ym4Bp0HTP7F3VFssV88WD1ZyCIRoE8H35pXSKwLeMizcdZAYc/t6N9X9Yr9n6t3aG9IH75XDnZ6UeZph0vHMWQ==
   dependencies:
-    "@octokit/types" "^6.0.3"
+    "@octokit/types" "^7.0.0"
     deprecation "^2.0.0"
     once "^1.4.0"
 
 "@octokit/request@^6.0.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-6.2.0.tgz#9c25606df84e6f2ccbcc2c58e1d35438e20b688b"
-  integrity sha512-7IAmHnaezZrgUqtRShMlByJK33MT9ZDnMRgZjnRrRV9a/jzzFwKGz0vxhFU6i7VMLraYcQ1qmcAOin37Kryq+Q==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-6.2.1.tgz#3ceeb22dab09a29595d96594b6720fc14495cf4e"
+  integrity sha512-gYKRCia3cpajRzDSU+3pt1q2OcuC6PK8PmFIyxZDWCzRXRSIBH8jXjFJ8ZceoygBIm0KsEUg4x1+XcYBz7dHPQ==
   dependencies:
     "@octokit/endpoint" "^7.0.0"
     "@octokit/request-error" "^3.0.0"
-    "@octokit/types" "^6.16.1"
+    "@octokit/types" "^7.0.0"
     is-plain-object "^5.0.0"
     node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^19.0.3":
-  version "19.0.3"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-19.0.3.tgz#b9a4e8dc8d53e030d611c053153ee6045f080f02"
-  integrity sha512-5arkTsnnRT7/sbI4fqgSJ35KiFaN7zQm0uQiQtivNQLI8RQx8EHwJCajcTUwmaCMNDg7tdCvqAnc7uvHHPxrtQ==
+  version "19.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-19.0.4.tgz#fd8bed1cefffa486e9ae46a9dc608ce81bcfcbdd"
+  integrity sha512-LwG668+6lE8zlSYOfwPj4FxWdv/qFXYBpv79TWIQEpBLKA9D/IMcWsF/U9RGpA3YqMVDiTxpgVpEW3zTFfPFTA==
   dependencies:
     "@octokit/core" "^4.0.0"
-    "@octokit/plugin-paginate-rest" "^3.0.0"
+    "@octokit/plugin-paginate-rest" "^4.0.0"
     "@octokit/plugin-request-log" "^1.0.4"
     "@octokit/plugin-rest-endpoint-methods" "^6.0.0"
 
-"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.41.0":
-  version "6.41.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.41.0.tgz#e58ef78d78596d2fb7df9c6259802464b5f84a04"
-  integrity sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==
+"@octokit/types@^7.0.0", "@octokit/types@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-7.1.1.tgz#a30fd6ca3279d59d532fa75583d65d93b7588e6d"
+  integrity sha512-Dx6cNTORyVaKY0Yeb9MbHksk79L8GXsihbG6PtWqTpkyA2TY1qBWE26EQXVG3dHwY9Femdd/WEeRUEiD0+H3TQ==
   dependencies:
-    "@octokit/openapi-types" "^12.11.0"
+    "@octokit/openapi-types" "^13.4.0"
 
 "@rollup/plugin-alias@^3.1.9":
   version "3.1.9"
@@ -1239,9 +1263,9 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.182"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
-  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+  version "4.14.184"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.184.tgz#23f96cd2a21a28e106dc24d825d4aa966de7a9fe"
+  integrity sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==
 
 "@types/mdast@^3.0.0":
   version "3.0.10"
@@ -1968,10 +1992,15 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001373:
+caniuse-lite@^1.0.0:
   version "1.0.30001374"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz#3dab138e3f5485ba2e74bd13eca7fe1037ce6f57"
   integrity sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==
+
+caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001373:
+  version "1.0.30001380"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001380.tgz#6f2427ad8ebee1b400a38ca3560515756ba352bb"
+  integrity sha512-OO+pPubxx16lkI7TVrbFpde8XHz66SMwstl1YWpg6uMGw56XnhYVwtPIjvX4kYpzwMwQKr4DDce394E03dQPGg==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -2546,9 +2575,9 @@ defu@^3.2.2:
   integrity sha512-8UWj5lNv7HD+kB0e9w77Z7TdQlbUYDVWqITLHNqFIn6khrNHv5WQo38Dcm1f6HeNyZf0U7UbPf6WeZDSdCzGDQ==
 
 defu@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/defu/-/defu-6.0.0.tgz#b397a6709a2f3202747a3d9daf9446e41ad0c5fc"
-  integrity sha512-t2MZGLf1V2rV4VBZbWIaXKdX/mUcYW0n2znQZoADBkGGxYL8EWqCuCZBmJPJ/Yy9fofJkyuuSuo5GSwo0XdEgw==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.0.tgz#7a5411655da73335c7d933256911f17c74443e2d"
+  integrity sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -2702,9 +2731,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.202:
-  version "1.4.212"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.212.tgz#20cd48e88288fd2428138c108804edb1961bf559"
-  integrity sha512-LjQUg1SpLj2GfyaPDVBUHdhmlDU1vDB4f0mJWSGkISoXQrn5/lH3ECPCuo2Bkvf6Y30wO+b69te+rZK/llZmjg==
+  version "1.4.225"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz#3e27bdd157cbaf19768141f2e0f0f45071e52338"
+  integrity sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -3089,19 +3118,12 @@ fraction.js@^4.2.0:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
-framesync@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.0.1.tgz#5e32fc01f1c42b39c654c35b16440e07a25d6f20"
-  integrity sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==
+framesync@6.1.2, framesync@^6.1.0:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.1.2.tgz#755eff2fb5b8f3b4d2b266dd18121b300aefea27"
+  integrity sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==
   dependencies:
-    tslib "^2.1.0"
-
-framesync@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.1.0.tgz#b22cf9afba52a9a895668b09e033b6a61e901c41"
-  integrity sha512-aBX+hdWAvwiJYeQlFLY2533VxeL6OEu71CAgV4GGKksrj6+dE6i7K86WSSiRBEARCoJn5bFqffhg4l07eA27tg==
-  dependencies:
-    tslib "^2.3.1"
+    tslib "2.4.0"
 
 fresh@0.5.2, fresh@~0.5.2:
   version "0.5.2"
@@ -3314,7 +3336,17 @@ gzip-size@^7.0.0:
   dependencies:
     duplexer "^0.1.2"
 
-h3@^0.7.12, h3@^0.7.14, h3@^0.7.6:
+h3@^0.7.12, h3@^0.7.6:
+  version "0.7.15"
+  resolved "https://registry.yarnpkg.com/h3/-/h3-0.7.15.tgz#34b1d5cbded0c7491f629b4e3031ac9521785076"
+  integrity sha512-4lile6Q64nQ5Z2+6NaD85WU64fhF/qIVyGm4NaFyl4w7L/XDIiq5gkogWLUzZGGtq60M4tnFSj7qIxc0rmTqrg==
+  dependencies:
+    cookie-es "^0.5.0"
+    destr "^1.1.1"
+    radix3 "^0.1.2"
+    ufo "^0.8.5"
+
+h3@^0.7.14:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/h3/-/h3-0.7.14.tgz#ec7f69737e5382384511f72c92ea45a1b0fc264d"
   integrity sha512-qF49Le5rhn9L+Kg7Dbd5JPdxr/JldWCLDMvFi46D/Pvqdzp6WQJyje2zm/ShfO8Ni+MFwA3efn1ldEAhznkAJQ==
@@ -3928,7 +3960,7 @@ json5@^2.1.2, json5@^2.2.0, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
-jsonc-parser@^3.0.0:
+jsonc-parser@^3.0.0, jsonc-parser@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.1.0.tgz#73b8f0e5c940b83d03476bc2e51a20ef0932615d"
   integrity sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==
@@ -4813,7 +4845,17 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mlly@^0.5.2, mlly@^0.5.3, mlly@^0.5.4, mlly@^0.5.5, mlly@^0.5.7:
+mlly@^0.5.12, mlly@^0.5.13, mlly@^0.5.4, mlly@^0.5.5, mlly@^0.5.7:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-0.5.13.tgz#2ee8fbaadda0fccad4d1096d024b1fb0aaeea11e"
+  integrity sha512-0SK2fqoan+PMjADs4I2egAtrtNtpjqRez6PDTCeAdGjUQNJCvO5o9v2NEq52WA1jFmMU97qBr/JgdvCquehDbA==
+  dependencies:
+    acorn "^8.8.0"
+    pathe "^0.3.4"
+    pkg-types "^0.3.3"
+    ufo "^0.8.5"
+
+mlly@^0.5.2:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/mlly/-/mlly-0.5.7.tgz#3b058c36268314a1670f89767d40eead66099b93"
   integrity sha512-rz+n2i9862ymLH+UDlHpsuTVyCIAs+9WejS2De2VUlAKdpq8OJ9x/C2M7nNUMLEW1H+D6n0uZlpz8+tMGxCmyQ==
@@ -5323,10 +5365,10 @@ pathe@^0.2.0:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-0.2.0.tgz#30fd7bbe0a0d91f0e60bae621f5d19e9e225c339"
   integrity sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==
 
-pathe@^0.3.0, pathe@^0.3.2, pathe@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/pathe/-/pathe-0.3.3.tgz#8d6d70a25d4db6024ed4d59e59c1bf80fcf18753"
-  integrity sha512-x3nrPvG0HDSDzUiJ0WqtzhN4MD+h5B+dFJ3/qyxVuARlr4Y3aJv8gri2cZzp9Z8sGs2a+aG9gNbKngh3gme57A==
+pathe@^0.3.0, pathe@^0.3.2, pathe@^0.3.3, pathe@^0.3.4, pathe@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-0.3.5.tgz#87e5c1164ded1bebeb9dea5dab63563144062303"
+  integrity sha512-grU/QeYP0ChuE5kjU2/k8VtAeODzbernHlue0gTa27+ayGIu3wqYBIPGfP9r5xSqgCgDd4nWrjKXEfxMillByg==
 
 perfect-debounce@^0.1.3:
   version "0.1.3"
@@ -5349,13 +5391,13 @@ pify@^2.3.0:
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
 pkg-types@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-0.3.3.tgz#3c25e45274e1c586ec7811dcc3449afde846e463"
-  integrity sha512-6AJcCMnjUQPQv/Wk960w0TOmjhdjbeaQJoSKWRQv9N3rgkessCu6J0Ydsog/nw1MbpnxHuPzYbfOn2KmlZO1FA==
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-0.3.4.tgz#bafb9ce824f78c93e50aaafb5accf41d8f2ef92f"
+  integrity sha512-s214f/xkRpwlwVBToWq9Mu0XlU3HhZMYCnr2var8+jjbavBHh/VCh4pBLsJW29rJ//B1jb4HlpMIaNIMH+W2/w==
   dependencies:
-    jsonc-parser "^3.0.0"
-    mlly "^0.5.3"
-    pathe "^0.3.0"
+    jsonc-parser "^3.1.0"
+    mlly "^0.5.13"
+    pathe "^0.3.5"
 
 plausible-tracker@^0.3.4:
   version "0.3.8"
@@ -5363,19 +5405,19 @@ plausible-tracker@^0.3.4:
   integrity sha512-lmOWYQ7s9KOUJ1R+YTOR3HrjdbxIS2Z4de0P/Jx2dQPteznJl2eX3tXxKClpvbfyGP59B5bbhW8ftN59HbbFSg==
 
 popmotion@^11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.3.tgz#565c5f6590bbcddab7a33a074bb2ba97e24b0cc9"
-  integrity sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.5.tgz#8e3e014421a0ffa30ecd722564fd2558954e1f7d"
+  integrity sha512-la8gPM1WYeFznb/JqF4GiTkRRPZsfaj2+kCxqQgr2MJylMmIKUwBfWW8Wa5fml/8gmtlD5yI01MP1QCZPWmppA==
   dependencies:
-    framesync "6.0.1"
+    framesync "6.1.2"
     hey-listen "^1.0.8"
-    style-value-types "5.0.0"
-    tslib "^2.1.0"
+    style-value-types "5.1.2"
+    tslib "2.4.0"
 
 portfinder@^1.0.26:
-  version "1.0.29"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.29.tgz#d06ff886f4ff91274ed3e25c7e6b0c68d2a0735a"
-  integrity sha512-Z5+DarHWCKlufshB9Z1pN95oLtANoY5Wn9X3JGELGyQ6VhEcBfT2t+1fGUBq7MwUant6g/mqowH+4HifByPbiQ==
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.32.tgz#2fe1b9e58389712429dc2bea5beb2146146c7f81"
+  integrity sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==
   dependencies:
     async "^2.6.4"
     debug "^3.2.7"
@@ -5939,9 +5981,9 @@ remark-github@^11.2.4:
     unist-util-visit "^4.0.0"
 
 remark-mdc@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/remark-mdc/-/remark-mdc-1.0.4.tgz#e871e62d4e0e3cec98be3282170d3ddf1827b189"
-  integrity sha512-bitabCV+w3Ma5yDFSbkVd6z+JtAV0MjzJmF0U6S3bA4kQU8KaqYpQJH/LfuGpyY+oASvF3WaPwn8n/wAVEWJUA==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/remark-mdc/-/remark-mdc-1.0.7.tgz#eca877a6e1e7320df7bfe367b157254cb9e5127e"
+  integrity sha512-qKIvlYQz7mCZlzAf30sgLfZAxw9mQfVq4CoL1K3X4DK5V/ABYyFc6i4S3gbZjQJTv+DF1OMNJ0Zct+yGdGI0Xw==
   dependencies:
     flat "^5.0.2"
     js-yaml "^4.1.0"
@@ -6366,9 +6408,9 @@ statuses@2.0.1:
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
 std-env@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.1.1.tgz#1f19c4d3f6278c52efd08a94574a2a8d32b7d092"
-  integrity sha512-/c645XdExBypL01TpFKiG/3RAa/Qmu+zRi0MwAmrdEkwHNuN0ebo8ccAXBBDa5Z0QOJgBskUIbuCK91x0sCVEw==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.2.1.tgz#00e260ec3901333537125f81282b9296b00d7304"
+  integrity sha512-D/uYFWkI/31OrnKmXZqGAGK5GbQRPp/BWA1nuITcc6ICblhhuQUPHS5E2GSCVS7Hwhf4ciq8qsATwBUxv+lI6w==
 
 storyblok-algolia-indexer@^1.0.3:
   version "1.0.3"
@@ -6464,21 +6506,13 @@ style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-style-value-types@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.0.0.tgz#76c35f0e579843d523187989da866729411fc8ad"
-  integrity sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==
+style-value-types@5.1.2, style-value-types@^5.1.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.1.2.tgz#6be66b237bd546048a764883528072ed95713b62"
+  integrity sha512-Vs9fNreYF9j6W2VvuDTP7kepALi7sk0xtk2Tu8Yxi9UoajJdEVpNpCov0HsLTqXvNGKX+Uv09pkozVITi1jf3Q==
   dependencies:
     hey-listen "^1.0.8"
-    tslib "^2.1.0"
-
-style-value-types@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.1.0.tgz#228b02bd9418c57db46c1f450b85577e634a877f"
-  integrity sha512-DRIfBtjxQ4ztBZpexkFcI+UR7pODC5qLMf2Syt+bH98PAHHRH2tQnzxBuDQlqcAoYar6GzWnj8iAfqfwnEzCiQ==
-  dependencies:
-    hey-listen "^1.0.8"
-    tslib "^2.3.1"
+    tslib "2.4.0"
 
 stylehacks@^5.1.0:
   version "5.1.0"
@@ -6677,7 +6711,7 @@ trough@^2.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
   integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1:
+tslib@2.4.0, tslib@^2.0.3, tslib@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -6736,9 +6770,9 @@ unctx@^2.0.1:
     unplugin "^0.8.0"
 
 undici@^5.2.0:
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.8.2.tgz#071fc8a6a5d24db0ad510ad442f607d9b09d5eec"
-  integrity sha512-3KLq3pXMS0Y4IELV045fTxqz04Nk9Ms7yfBBHum3yxsTR4XNn+ZCaUbf/mWitgYDAhsplQ0B1G4S5D345lMO3A==
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.9.1.tgz#fc9fd85dd488f965f153314a63d9426a11f3360b"
+  integrity sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==
 
 unenv@^0.5.3:
   version "0.5.3"
@@ -6794,6 +6828,22 @@ unimport@^0.6.5:
     scule "^0.3.2"
     strip-literal "^0.4.0"
     unplugin "^0.8.1"
+
+unimport@^0.6.7:
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/unimport/-/unimport-0.6.7.tgz#7b2e2063b88ee8ea363d2d751f7c82a6960beac3"
+  integrity sha512-EMoVqDjswHkU+nD098QYHXH7Mkw7KwGDQAyeRF2lgairJnuO+wpkhIcmCqrD1OPJmsjkTbJ2tW6Ap8St0PuWZA==
+  dependencies:
+    "@rollup/pluginutils" "^4.2.1"
+    escape-string-regexp "^5.0.0"
+    fast-glob "^3.2.11"
+    local-pkg "^0.4.2"
+    magic-string "^0.26.2"
+    mlly "^0.5.7"
+    pathe "^0.3.3"
+    scule "^0.3.2"
+    strip-literal "^0.4.0"
+    unplugin "^0.9.0"
 
 unist-builder@^3.0.0:
   version "3.0.0"
@@ -6892,9 +6942,9 @@ unplugin@^0.8.0, unplugin@^0.8.1:
     webpack-virtual-modules "^0.4.4"
 
 unplugin@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-0.9.0.tgz#ebad287d61aa1b1f16de60feea74e8dd12224819"
-  integrity sha512-6o7q8Y9yxdPi5yCPmRuFfeNnVzGumRNZSK6hIkvZ6hd0cfigVdm0qBx/GgQ/NEjs54eUV1qTjvMYKRs9yh3rzw==
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-0.9.3.tgz#baeec1e3d70d18f693597ef3fcc441779e164e7f"
+  integrity sha512-GWXxizZG+tobNs8fuGTCeilerkkfZTZax2iivuE4pxLaF9wTnPJHOq8tbLKDb5ohVb+2BXNjrU9xx59yWTUnuw==
   dependencies:
     acorn "^8.8.0"
     chokidar "^3.5.3"
@@ -7113,9 +7163,9 @@ vue-bundle-renderer@^0.4.1:
     ufo "^0.8.3"
 
 vue-demi@*:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.6.tgz#f9433cbd75e68a970dec066647f4ba6c08ced48f"
-  integrity sha512-02NYpxgyGE2kKGegRPYlNQSL1UWfA/+JqvzhGCOYjhfbLWXU5QQX0+9pAm/R2sCOPKr5NBxVIab7fvFU0B1RxQ==
+  version "0.13.8"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.8.tgz#5c568fb3b4d8f848acc658dfccd3d875035b5653"
+  integrity sha512-Vy1zbZhCOdsmvGR6tJhAvO5vhP7eiS8xkbYQSoVa7o6KlIy3W8Rc53ED4qI4qpeRDjv3mLfXSEpYU6Yq4pgXRg==
 
 vue-instantsearch@^4.3.2:
   version "4.4.2"


### PR DESCRIPTION
### 🔗 Linked issue

closes #148

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

To adept to new typescript standards `declare name: string` is now the recommonded way to define types in classes instead of `name!: string`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
