### PR TITLE
fix(pinia-orm): multiple belongsTo relationships between 2 entities lead to unintended outcome

### DIFF
--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -335,16 +335,18 @@ export class Model {
   ): BelongsToMany {
     const instance = related.newRawInstance()
     const model = this.newRawInstance()
+    const pivotInstance = pivot.newRawInstance()
 
     parentKey = parentKey ?? model.$getLocalKey()
     relatedKey = relatedKey ?? instance.$getLocalKey()
 
-    this.schemas[related.entity].pivot = new HasOne(instance, pivot.newRawInstance(), relatedPivotKey, relatedKey)
+    this.schemas[related.entity].pivot = new HasOne(instance, pivotInstance, relatedPivotKey, relatedKey)
+    this.schemas[related.entity][`pivot_${pivotInstance.$entity()}`] = this.schemas[related.entity].pivot
 
     return new BelongsToMany(
       model,
       instance,
-      pivot.newRawInstance(),
+      pivotInstance,
       foreignPivotKey,
       relatedPivotKey,
       parentKey,

--- a/packages/pinia-orm/src/model/attributes/relations/BelongsToMany.ts
+++ b/packages/pinia-orm/src/model/attributes/relations/BelongsToMany.ts
@@ -79,6 +79,7 @@ export class BelongsToMany extends Relation {
     pivot[this.foreignPivotKey] = record[this.parentKey]
     pivot[this.relatedPivotKey] = child[this.relatedKey]
     child.pivot = pivot
+    child[`pivot_${this.pivot.$entity()}`] = pivot
   }
 
   /**


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#363

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently it wasn't possible to have multiple mn pivot tables with the same models. Kind of edge case 🤔  
Look into related issue for more detail. 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
