### PR TITLE
fix(pinia-orm): `whereId` can't be called with repository

### DIFF
--- a/packages/pinia-orm/src/repository/Repository.ts
+++ b/packages/pinia-orm/src/repository/Repository.ts
@@ -144,6 +144,13 @@ export class Repository<M extends Model = Model> {
   }
 
   /**
+   * Add a where clause on the primary key to the query.
+   */
+  whereId(ids: string | number | (string | number)[]): Query<M> {
+    return this.query().whereId(ids)
+  }
+
+  /**
    * Add an "or where" clause to the query.
    */
   orWhere(

--- a/packages/pinia-orm/tests/feature/repository/retrieves_where.spec.ts
+++ b/packages/pinia-orm/tests/feature/repository/retrieves_where.spec.ts
@@ -101,4 +101,27 @@ describe('feature/repository/retrieves_where', () => {
     assertInstanceOf(users, User)
     assertModels(users, expected)
   })
+
+  it('can filter records with "whereId"', () => {
+    const userRepo = useRepo(User)
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+        2: { id: 2, name: 'Jane Doe', age: 30 },
+        3: { id: 3, name: 'Johnny Doe', age: 20 },
+      },
+    })
+
+    const users = userRepo.whereId([1, 2]).get()
+
+    const expected = [
+      { id: 1, name: 'John Doe', age: 30 },
+      { id: 2, name: 'Jane Doe', age: 30 },
+    ]
+
+    expect(users).toHaveLength(2)
+    assertInstanceOf(users, User)
+    assertModels(users, expected)
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#427 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

adds `whereId` to repository

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
