### PR TITLE
feat(pinia-orm): Enhance `whereIn` to support Set as values

### DIFF
--- a/docs/content/2.api/3.query/where-in.md
+++ b/docs/content/2.api/3.query/where-in.md
@@ -11,12 +11,15 @@ import User from './models/User'
 
 const userRepo = useRepo(User)
 
-console.log(userRepo.whereIn('commentIds', [1,2,5]).get()) // User[]
+// Filter by array
+console.log(userRepo.query().whereIn('commentIds', [1,2,5]).get())
+// Filter by Set
+console.log(userRepo.query().whereIn('commentIds', new Set([1,2,5])).get())
 
 ````
 
 ## Typescript Declarations
 
 ````ts
-function whereIn(field: string, values: any[]): Query
+function whereIn(field: string, values: any[]|Set): Query
 ````

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -197,7 +197,10 @@ export class Query<M extends Model = Model> {
   /**
    * Add a "where in" clause to the query.
    */
-  whereIn(field: string, values: any[]): this {
+  whereIn(field: string, values: any[] | Set<any>): this {
+    if (values instanceof Set)
+      values = Array.from(values)
+
     this.wheres.push({ field, value: values, boolean: 'and' })
 
     return this

--- a/packages/pinia-orm/tests/feature/repository/retrieves_where.spec.ts
+++ b/packages/pinia-orm/tests/feature/repository/retrieves_where.spec.ts
@@ -101,4 +101,29 @@ describe('feature/repository/retrieves_where', () => {
     assertInstanceOf(users, User)
     assertModels(users, expected)
   })
+
+  it('can filter records by Set', () => {
+    const userRepo = useRepo(User)
+
+    const ages = new Set([40, 30])
+
+    fillState({
+      users: {
+        1: { id: 1, name: 'John Doe', age: 40 },
+        2: { id: 2, name: 'Jane Doe', age: 30 },
+        3: { id: 3, name: 'Johnny Doe', age: 20 },
+      },
+    })
+
+    const users = userRepo.query().whereIn('age', ages).get()
+
+    const expected = [
+      { id: 1, name: 'John Doe', age: 40 },
+      { id: 2, name: 'Jane Doe', age: 30 },
+    ]
+
+    expect(users).toHaveLength(2)
+    assertInstanceOf(users, User)
+    assertModels(users, expected)
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#524 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Makes it possible to use `whereIn` with `Set`

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
