### PR TITLE
feat(pinia-orm): Attributes can now accept closures for default value

### DIFF
--- a/docs/content/1.guide/2.model/1.getting-started.md
+++ b/docs/content/1.guide/2.model/1.getting-started.md
@@ -59,7 +59,8 @@ class User extends Model {
   static fields () {
     return {
       id: this.attr(null),
-      name: this.attr('John Doe')
+      name: this.attr('John Doe'),
+      address: this.attr(() => 'street')
     }
   }
 }
@@ -71,7 +72,7 @@ class User extends Model {
 If your value is not of the given type `string` you will get a console warning
 ::
 
-String attributes can be defined using `this.string(...)`. The default value can be any string, including an empty string.
+String attributes can be defined using `this.string(...)`. The default value can be any string, including an empty string or a closure.
 
 The following example defines the `name` field on a user model using the string attribute:
 
@@ -105,7 +106,7 @@ This attribute has `null` as a default value. However, if you want to get warnin
 If your value is not of the given type `number` you will get a console warning
 ::
 
-Number attributes can be defined using `this.number(...)`. The default value can be any integer.
+Number attributes can be defined using `this.number(...)`. The default value can be any integer or a closure.
 
 The following example defines the `id` field on a user model using the number attribute:
 
@@ -139,7 +140,7 @@ This attribute has `null` as a default value. However, if you want to get warnin
 If your value is not of the given type `boolean` you will get a console warning
 ::
 
-Boolean attributes can be defined using `this.boolean(...)`. The default value can be either `true` or `false`.
+Boolean attributes can be defined using `this.boolean(...)`. The default value can be either `true` or `false` or a closure.
 
 The following example defines the `active` field on a user model using the boolean attribute:
 

--- a/docs/content/2.api/2.model/1.fields-attributes/attr.md
+++ b/docs/content/2.api/2.model/1.fields-attributes/attr.md
@@ -14,7 +14,8 @@ class User extends Model {
   static fields () {
     return {
       id: this.attr(null),
-      name: this.attr('John Doe')
+      name: this.attr('John Doe'),
+      address: this.attr(() => 'Address'),
     }
   }
 }
@@ -31,11 +32,12 @@ class User extends Model {
   
   @Attr(null) declare id: number | null
   @Attr('') declare name: string
+  @Attr(() => 'street') declare address: string
 }
 ````
 
 ## Typescript Declarations
 
 ````ts
-function attr(value: any): Attr
+function attr(value: any | (() => any)): Attr
 ````

--- a/docs/content/2.api/2.model/1.fields-attributes/boolean.md
+++ b/docs/content/2.api/2.model/1.fields-attributes/boolean.md
@@ -14,7 +14,8 @@ class User extends Model {
   static fields () {
     return {
       id: this.number(0),
-      published: this.boolean(false)
+      published: this.boolean(false),
+      released: this.boolean(() => false),
     }
   }
 }
@@ -31,11 +32,12 @@ class User extends Model {
   
   @Num(0) declare id: number
   @Bool(false) declare published: boolean
+  @Bool(() => false) declare released: boolean
 }
 ````
 
 ## Typescript Declarations
 
 ````ts
-function boolean(value: boolean | null): Bool
+function boolean(value: boolean | null | (() => boolean | null)): Bool
 ````

--- a/docs/content/2.api/2.model/1.fields-attributes/number.md
+++ b/docs/content/2.api/2.model/1.fields-attributes/number.md
@@ -14,6 +14,7 @@ class User extends Model {
   static fields () {
     return {
       id: this.number(0)
+      extraId: this.number(() => 0)
     }
   }
 }
@@ -29,11 +30,12 @@ class User extends Model {
   static entity = 'users'
   
   @Num(0) declare id: number
+  @Num(() => 0) declare extraId: number
 }
 ````
 
 ## Typescript Declarations
 
 ````ts
-function number(value: number | null): Number
+function number(value: number | null | (() => number | null)): Number
 ````

--- a/docs/content/2.api/2.model/1.fields-attributes/string.md
+++ b/docs/content/2.api/2.model/1.fields-attributes/string.md
@@ -15,6 +15,7 @@ class User extends Model {
     return {
       id: this.number(0),
       name: this.string('')
+      address: this.string(() => 'street')
     }
   }
 }
@@ -31,11 +32,12 @@ class User extends Model {
   
   @Num(0) declare id: number
   @Str('') declare name: string
+  @Str(() => 'street') declare address: string
 }
 ````
 
 ## Typescript Declarations
 
 ````ts
-function string(value: string | null): String
+function string(value: string | null | (() => string | null)): String
 ````

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -22,7 +22,7 @@ import { MorphOne } from './attributes/relations/MorphOne'
 import { MorphTo } from './attributes/relations/MorphTo'
 import { MorphMany } from './attributes/relations/MorphMany'
 import type { CastAttribute, Casts } from './casts/CastAttribute'
-import {TypeDefault} from "@/model/attributes/types/Type";
+import type { TypeDefault } from './attributes/types/Type'
 
 export type ModelFields = Record<string, Attribute>
 export type ModelSchemas = Record<string, ModelFields>

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -22,6 +22,7 @@ import { MorphOne } from './attributes/relations/MorphOne'
 import { MorphTo } from './attributes/relations/MorphTo'
 import { MorphMany } from './attributes/relations/MorphMany'
 import type { CastAttribute, Casts } from './casts/CastAttribute'
+import {TypeDefault} from "@/model/attributes/types/Type";
 
 export type ModelFields = Record<string, Attribute>
 export type ModelSchemas = Record<string, ModelFields>
@@ -282,28 +283,28 @@ export class Model {
   /**
    * Create a new Attr attribute instance.
    */
-  static attr(value: any): Attr {
+  static attr(value: TypeDefault<any>): Attr {
     return new Attr(this.newRawInstance(), value)
   }
 
   /**
    * Create a new String attribute instance.
    */
-  static string(value: string | null): Str {
+  static string(value: TypeDefault<string>): Str {
     return new Str(this.newRawInstance(), value)
   }
 
   /**
    * Create a new Number attribute instance.
    */
-  static number(value: number | null): Num {
+  static number(value: TypeDefault<number>): Num {
     return new Num(this.newRawInstance(), value)
   }
 
   /**
    * Create a new Boolean attribute instance.
    */
-  static boolean(value: boolean | null): Bool {
+  static boolean(value: TypeDefault<boolean>): Bool {
     return new Bool(this.newRawInstance(), value)
   }
 

--- a/packages/pinia-orm/src/model/attributes/types/Boolean.ts
+++ b/packages/pinia-orm/src/model/attributes/types/Boolean.ts
@@ -1,11 +1,12 @@
 import type { Model } from '../../Model'
+import type { TypeDefault } from './Type'
 import { Type } from './Type'
 
 export class Boolean extends Type {
   /**
    * Create a new Boolean attribute instance.
    */
-  constructor(model: Model, value: boolean | null) {
+  constructor(model: Model, value: TypeDefault<boolean>) {
     super(model, value)
   }
 

--- a/packages/pinia-orm/src/model/attributes/types/Number.ts
+++ b/packages/pinia-orm/src/model/attributes/types/Number.ts
@@ -1,11 +1,12 @@
 import type { Model } from '../../Model'
+import type { TypeDefault } from './Type'
 import { Type } from './Type'
 
 export class Number extends Type {
   /**
    * Create a new Number attribute instance.
    */
-  constructor(model: Model, value: number | null) {
+  constructor(model: Model, value: TypeDefault<number>) {
     super(model, value)
   }
 

--- a/packages/pinia-orm/src/model/attributes/types/String.ts
+++ b/packages/pinia-orm/src/model/attributes/types/String.ts
@@ -1,11 +1,12 @@
 import type { Model } from '../../Model'
+import type { TypeDefault } from './Type'
 import { Type } from './Type'
 
 export class String extends Type {
   /**
    * Create a new String attribute instance.
    */
-  constructor(model: Model, value: string | null) {
+  constructor(model: Model, value: TypeDefault<string>) {
     super(model, value)
   }
 

--- a/packages/pinia-orm/src/model/attributes/types/Type.ts
+++ b/packages/pinia-orm/src/model/attributes/types/Type.ts
@@ -1,6 +1,8 @@
 import type { Model } from '../../Model'
 import { Attribute } from '../Attribute'
 
+export type TypeDefault<T> = T | null | (() => T | null)
+
 export abstract class Type extends Attribute {
   /**
    * The default value for the attribute.
@@ -15,9 +17,9 @@ export abstract class Type extends Attribute {
   /**
    * Create a new Type attribute instance.
    */
-  constructor(model: Model, value: any = null) {
+  constructor(model: Model, value: TypeDefault<any> = null) {
     super(model)
-    this.value = value
+    this.value = typeof value === 'function' ? value() : value
   }
 
   /**

--- a/packages/pinia-orm/src/model/decorators/attributes/types/Attr.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/types/Attr.ts
@@ -1,9 +1,10 @@
 import type { PropertyDecorator } from '../../Contracts'
+import type { TypeDefault } from '../../../attributes/types/Type'
 
 /**
  * Create an Attr attribute property decorator.
  */
-export function Attr(value?: any): PropertyDecorator {
+export function Attr(value?: TypeDefault<any>): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()
 

--- a/packages/pinia-orm/src/model/decorators/attributes/types/Bool.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/types/Bool.ts
@@ -1,10 +1,11 @@
 import type { PropertyDecorator, TypeOptions } from '../../Contracts'
+import type { TypeDefault } from '../../../attributes/types/Type'
 
 /**
  * Create a Boolean attribute property decorator.
  */
 export function Bool(
-  value: boolean | null,
+  value: TypeDefault<boolean>,
   options: TypeOptions = {},
 ): PropertyDecorator {
   return (target, propertyKey) => {

--- a/packages/pinia-orm/src/model/decorators/attributes/types/Num.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/types/Num.ts
@@ -1,10 +1,11 @@
 import type { PropertyDecorator, TypeOptions } from '../../Contracts'
+import type { TypeDefault } from '../../../attributes/types/Type'
 
 /**
  * Create a Number attribute property decorator.
  */
 export function Num(
-  value: number | null,
+  value: TypeDefault<number>,
   options: TypeOptions = {},
 ): PropertyDecorator {
   return (target, propertyKey) => {

--- a/packages/pinia-orm/src/model/decorators/attributes/types/Str.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/types/Str.ts
@@ -1,10 +1,11 @@
 import type { PropertyDecorator, TypeOptions } from '../../Contracts'
+import type { TypeDefault } from '../../../attributes/types/Type'
 
 /**
  * Create a String attribute property decorator.
  */
 export function Str(
-  value: string | null,
+  value: TypeDefault<string>,
   options: TypeOptions = {},
 ): PropertyDecorator {
   return (target, propertyKey) => {

--- a/packages/pinia-orm/tests/unit/model/Model_Attrs_String.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Attrs_String.spec.ts
@@ -36,4 +36,14 @@ describe('unit/model/Model_Attrs_String', () => {
     expect(new User({ str: null }).str).toBe(null)
     expect(logger).toBeCalledTimes(3)
   })
+
+  it('accepts a closure as default value', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Str(() => 'Test') declare str: string
+    }
+
+    expect(new User({}).str).toBe('Test')
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #542 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add the possibilty to pass closures for attributes as default value.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
