### PR TITLE
fix(pinia-orm): using childRepo (STI) for saving without type defined

### DIFF
--- a/docs/content/1.guide/2.model/7.single-table-inheritance.md
+++ b/docs/content/1.guide/2.model/7.single-table-inheritance.md
@@ -242,7 +242,8 @@ class Adult extends Person {
   static fields () {
     return {
       ...super.fields(),
-      job: this.attr('')
+      job: this.attr(''),
+      type: this.attr('ADULT') // necessary fallback if you use the childRepo directly without type
     }
   } 
 }
@@ -358,3 +359,38 @@ const people = useRepo(Person).query().with(['home_address', 'work_address']).ge
 ]
 */
 ```
+
+## Example with decorators
+
+If you are using decorators you need to use `...super.schemas[super.entity]` instead of `...super.fields()`.
+
+````ts
+    class Animal extends Model {
+      static entity = 'animals'
+
+      @Attr(null) declare id: number | null
+      @Attr('animal') declare type: string
+
+      static types() {
+        return {
+          animal: Animal,
+          dog: Dog,
+        }
+      }
+    }
+
+    class Dog extends Animal {
+      static entity = 'dogs'
+
+      static baseEntity = 'animals'
+
+      static fields() {
+        return {
+          ...super.schemas[super.entity],
+        }
+      }
+
+      @Attr('dog') declare type
+      @Attr('terrier') declare race: string
+    }
+````

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -716,8 +716,8 @@ export class Model {
   }
 
   protected isFieldVisible(key: string, modelHidden: string[], modelVisible: string[], options: ModelOptions): boolean {
-    const hidden = modelHidden.length > 0 ? modelHidden : config.model.hidden ?? []
-    const visible = [...(modelVisible.length > 0 ? modelVisible : config.model.visible ?? ['*']), String(this.$primaryKey())]
+    const hidden = modelHidden.length > 0 ? modelHidden : config.model.hidden
+    const visible = [...(modelVisible.length > 0 ? modelVisible : config.model.visible), String(this.$primaryKey())]
     const optionsVisible = options.visible ?? []
     const optionsHidden = options.hidden ?? []
     if (((hidden.includes('*') || hidden.includes(key)) && !optionsVisible.includes(key)) || optionsHidden.includes(key))

--- a/packages/pinia-orm/src/model/attributes/types/Type.ts
+++ b/packages/pinia-orm/src/model/attributes/types/Type.ts
@@ -7,7 +7,7 @@ export abstract class Type extends Attribute {
   /**
    * The default value for the attribute.
    */
-  protected value: any
+  value: any
 
   /**
    * Whether the attribute accepts `null` value or not.

--- a/packages/pinia-orm/tests/unit/model/Model_STI.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_STI.spec.ts
@@ -61,19 +61,25 @@ describe('unit/model/Model_STI', () => {
       },
     ])
 
+    useRepo(Dog).save({
+      id: 4,
+      race: 'Rattler',
+    })
+
     assertState({
       animals: {
         1: { id: 1, type: 'animal' },
         2: { id: 2, type: 'dog', race: 'Rattler' },
         3: { id: 3, type: 'cat' },
+        4: { id: 4, type: 'dog', race: 'Rattler' },
       },
     })
 
     expect(animalsRepo.find(1)).toBeInstanceOf(Animal)
     expect(animalsRepo.find(2)).toBeInstanceOf(Dog)
     expect(animalsRepo.find(3)).toBeInstanceOf(Animal)
-    expect(animalsRepo.all().length).toBe(3)
-    expect(useRepo(Dog).all().length).toBe(1)
+    expect(animalsRepo.all().length).toBe(4)
+    expect(useRepo(Dog).all().length).toBe(2)
   })
 
   it('saves with deocrators the types correctly', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #522, related #519

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If you used a childRepo saving it without type than its defined default is not used:
e.g.:
````ts
  class Animal extends Model {
      static entity = 'animals'

      static fields() {
        return {
          id: this.attr(null),
          type: this.attr('animal'),
        }
      }

      static types() {
        return {
          animal: Animal,
          dog: Dog,
        }
      }
    }

    class Dog extends Animal {
      static entity = 'dogs'

      static baseEntity = 'animals'

      static fields() {
        return {
          ...super.fields(),
          type: this.attr('dog'),
          race: this.attr('terrier'),
        }
      }
    }

    const animalsRepo = useRepo(Animal)

    animalsRepo.save([
      {
        id: 1,
        type: 'animal',
      },
      {
        id: 2,
        type: 'dog',
        race: 'Rattler',
      },
      {
        id: 3,
        type: 'cat',
        race: 'red',
      },
    ])

    useRepo(Dog).save({
      id: 4,
      race: 'Rattler',
    })
````

---

Also updated docs with an example for decorators.

---

Removed unnecessary fallback for hidden fields

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
