### PR TITLE
fix(pinia-orm): delete on cascade doesn't work with n:m relations

### DIFF
--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -19,6 +19,7 @@ import type { CacheConfig } from '../types'
 import type { HasMany } from '../model/attributes/relations/HasMany'
 import type { MorphMany } from '../model/attributes/relations/MorphMany'
 import type { Type } from '../model/attributes/types/Type'
+import { BelongsToMany } from '../model/attributes/relations/BelongsToMany'
 import type {
   EagerLoad,
   EagerLoadConstraint,
@@ -889,6 +890,11 @@ export class Query<M extends Model = Model> {
           return relation[relation.$getLocalKey()]
         })
         const record = {}
+
+        if (relation instanceof BelongsToMany) {
+          this.newQuery(relation.pivot.$entity()).where(relation.foreignPivotKey, model[model.$getLocalKey()]).delete()
+          continue
+        }
 
         switch (relation.onDeleteMode) {
           case 'cascade': {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `onDelete('cascade')` method is not working wtih n:m relations (BelongsToMany).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
