### PR TITLE
feat(pinia-orm): Add the option to sort case insensitive with `sortBy`

### DIFF
--- a/docs/content/2.api/1.composables/2.helpers/use-collect.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-collect.md
@@ -41,7 +41,7 @@ export interface UseCollect<M extends Model = Model> {
   max: (field: string) => number
   pluck: (field: string) => any[]
   groupBy: (fields: string[] | string) => Record<string, Collection<M>>
-  sortBy: (sort: sorting<M>) => M[]
+  sortBy: (sort: sorting<M>, flags?: SortFlags) => M[]
   keys: () => string[]
 }
 

--- a/docs/content/2.api/1.composables/2.helpers/use-sort-by.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-sort-by.md
@@ -16,6 +16,10 @@ const users = useRepo(User).all()
 
 // sort by the 'name' attribute
 useSortBy(users, 'name')
+
+// sort by the `name` attribute case insensitive
+useSortBy(users, 'name', 'SORT_FLAG_CASE')
+
 // sorts the collection by 'name' descending and then by 'lastname' ascending
 useSortBy(users, [
     ['name', 'desc'],
@@ -31,6 +35,7 @@ useSortBy(users, (model) => model.age)
 
 ````ts
 export type sorting<T> = ((record: T) => any) | string | [string, 'asc' | 'desc'][]
+export type SortFlags = 'SORT_REGULAR' | 'SORT_FLAG_CASE'
 
-export function useSortBy<T>(collection: T[], sort: sorting<T>): T[]
+export function useSortBy<T>(collection: T[], sort: sorting<T>, flags?: SortFlags): T[]
 ````

--- a/packages/pinia-orm/src/composables/collection/useCollect.ts
+++ b/packages/pinia-orm/src/composables/collection/useCollect.ts
@@ -7,6 +7,7 @@ import { useKeys } from './useKeys'
 import { useGroupBy } from './useGroupBy'
 import type { sorting } from './useSortBy'
 import { useSortBy } from './useSortBy'
+import type { SortFlags } from '@/support/Utils'
 
 export interface UseCollect<M extends Model = Model> {
   sum: (field: string) => number
@@ -14,7 +15,7 @@ export interface UseCollect<M extends Model = Model> {
   max: (field: string) => number
   pluck: (field: string) => any[]
   groupBy: (fields: string[] | string) => Record<string, Collection<M>>
-  sortBy: (sort: sorting<M>) => M[]
+  sortBy: (sort: sorting<M>, flags?: SortFlags) => M[]
   keys: () => string[]
 }
 
@@ -28,7 +29,7 @@ export function useCollect<M extends Model = Model>(models: Collection<M>): UseC
     max: field => useMax(models, field),
     pluck: field => usePluck(models, field),
     groupBy: fields => useGroupBy(models, fields),
-    sortBy: sort => useSortBy(models, sort),
+    sortBy: (sort, flags: SortFlags = 'SORT_REGULAR') => useSortBy(models, sort, flags),
     keys: () => useKeys(models),
   }
 }

--- a/packages/pinia-orm/src/composables/collection/useSortBy.ts
+++ b/packages/pinia-orm/src/composables/collection/useSortBy.ts
@@ -1,3 +1,4 @@
+import type { SortFlags } from '../../support/Utils'
 import { orderBy } from '../../support/Utils'
 
 export type sorting<T> = ((record: T) => any) | string | [string, 'asc' | 'desc'][]
@@ -6,7 +7,7 @@ export type sorting<T> = ((record: T) => any) | string | [string, 'asc' | 'desc'
  * Creates an array of elements, sorted in specified order by the results
  * of running each element in a collection thru each iteratee.
  */
-export function useSortBy<T>(collection: T[], sort: sorting<T>): T[] {
+export function useSortBy<T>(collection: T[], sort: sorting<T>, flags?: SortFlags): T[] {
   const directions = []
   const iteratees = []
 
@@ -14,5 +15,5 @@ export function useSortBy<T>(collection: T[], sort: sorting<T>): T[] {
   Array.isArray(sort) && sort.forEach(item => iteratees.push(item[0]) && directions.push(item[1]))
   iteratees.length === 0 && iteratees.push(sort as string)
 
-  return orderBy(collection, iteratees, directions)
+  return orderBy(collection, iteratees, directions, flags)
 }

--- a/packages/pinia-orm/src/support/Utils.ts
+++ b/packages/pinia-orm/src/support/Utils.ts
@@ -4,6 +4,8 @@ interface SortableArray<T> {
   value: T
 }
 
+export type SortFlags = 'SORT_REGULAR' | 'SORT_FLAG_CASE'
+
 /**
  * Compare two values with custom string operator
  */
@@ -65,6 +67,7 @@ export function orderBy<T>(
   collection: T[],
   iteratees: (((record: T) => any) | string)[],
   directions: string[],
+  flags: SortFlags = 'SORT_REGULAR',
 ): T[] {
   let index = -1
 
@@ -77,7 +80,7 @@ export function orderBy<T>(
   })
 
   return baseSortBy(result, (object, other) => {
-    return compareMultiple(object, other, directions)
+    return compareMultiple(object, other, directions, flags)
   })
 }
 
@@ -114,6 +117,7 @@ function compareMultiple<T>(
   object: SortableArray<T>,
   other: SortableArray<T>,
   directions: string[],
+  flags: SortFlags,
 ): number {
   let index = -1
 
@@ -122,11 +126,10 @@ function compareMultiple<T>(
   const length = objCriteria.length
 
   while (++index < length) {
-    const result = compareAscending(objCriteria[index], othCriteria[index])
+    const result = compareAscending(objCriteria[index], othCriteria[index], flags)
 
     if (result) {
       const direction = directions[index]
-
       return result * (direction === 'desc' ? -1 : 1)
     }
   }
@@ -137,7 +140,7 @@ function compareMultiple<T>(
 /**
  * Compares values to sort them in ascending order.
  */
-function compareAscending(value: any, other: any): number {
+function compareAscending(value: any, other: any, flags: SortFlags): number {
   if (value !== other) {
     const valIsDefined = value !== undefined
     const valIsNull = value === null
@@ -149,6 +152,11 @@ function compareAscending(value: any, other: any): number {
     if (typeof value !== 'number' || typeof other !== 'number') {
       value = String(value)
       other = String(other)
+
+      if (flags === 'SORT_FLAG_CASE') {
+        value = value.toUpperCase()
+        other = other.toUpperCase()
+      }
     }
 
     if (

--- a/packages/pinia-orm/tests/unit/composables/Use_Collect.spec.ts
+++ b/packages/pinia-orm/tests/unit/composables/Use_Collect.spec.ts
@@ -27,6 +27,8 @@ describe('unit/composables/Collect', () => {
     { id: 1, name: 'James', age: 40, post: { id: 1, title: 'Title1' } },
     { id: 2, name: 'James', age: 30, post: { id: 2, title: 'Title2' } },
     { id: 3, name: 'David', age: 20 },
+    { id: 4, name: 'john', age: 20 },
+    { id: 5, name: 'Zod', age: 20 },
   ]))
 
   it('can group records using the "groupBy" modifier', () => {
@@ -37,6 +39,12 @@ describe('unit/composables/Collect', () => {
       ]),
       David: useRepo(User).make([
         { id: 3, name: 'David', age: 20, post: null },
+      ]),
+      john: useRepo(User).make([
+        { id: 4, name: 'john', age: 20, post: null },
+      ]),
+      Zod: useRepo(User).make([
+        { id: 5, name: 'Zod', age: 20, post: null },
       ]),
     }
 
@@ -50,6 +58,12 @@ describe('unit/composables/Collect', () => {
       '[David,20]': useRepo(User).make([
         { id: 3, name: 'David', age: 20 },
       ]),
+      '[john,20]': useRepo(User).make([
+        { id: 4, name: 'john', age: 20 },
+      ]),
+      '[Zod,20]': useRepo(User).make([
+        { id: 5, name: 'Zod', age: 20 },
+      ]),
     }
 
     expect(userCollection.groupBy('name')).toEqual(expected)
@@ -61,15 +75,26 @@ describe('unit/composables/Collect', () => {
       { id: 3, name: 'David', age: 20, post: null },
       { id: 1, name: 'James', age: 40, post: { id: 1, title: 'Title1' } },
       { id: 2, name: 'James', age: 30, post: { id: 2, title: 'Title2' } },
+      { id: 5, name: 'Zod', age: 20, post: null },
+      { id: 4, name: 'john', age: 20, post: null },
+    ])
+
+    const expected2 = useRepo(User).make([
+      { id: 3, name: 'David', age: 20, post: null },
+      { id: 1, name: 'James', age: 40, post: { id: 1, title: 'Title1' } },
+      { id: 2, name: 'James', age: 30, post: { id: 2, title: 'Title2' } },
+      { id: 4, name: 'john', age: 20, post: null },
+      { id: 5, name: 'Zod', age: 20, post: null },
     ])
 
     expect(userCollection.sortBy('name')).toEqual(expected)
+    expect(userCollection.sortBy('name', 'SORT_FLAG_CASE')).toEqual(expected2)
     expect(userCollection.sortBy(model => model.name)).toEqual(expected)
     expect(userCollection.sortBy([['name', 'asc']])).toEqual(expected)
   })
 
   it('can sum up by field name', () => {
-    expect(userCollection.sum('age')).toEqual(90)
+    expect(userCollection.sum('age')).toEqual(130)
     expect(userCollection.sum('name')).toEqual(0)
   })
 
@@ -84,11 +109,11 @@ describe('unit/composables/Collect', () => {
   })
 
   it('can pluck by field name', () => {
-    expect(userCollection.pluck('age')).toEqual([40, 30, 20])
+    expect(userCollection.pluck('age')).toEqual([40, 30, 20, 20, 20])
   })
 
   it('can return the keys of the collection', () => {
-    expect(userCollection.keys()).toEqual([1, 2, 3])
+    expect(userCollection.keys()).toEqual([1, 2, 3, 4, 5])
   })
 
   it('can pluck by field with dot notation', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#634 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adding the option to sort collections case insensitive:
````ts
const userCollection = useCollect(useRepo(User).make([
    { id: 1, name: 'James', age: 40, post: { id: 1, title: 'Title1' } },
    { id: 2, name: 'john', age: 30, post: { id: 2, title: 'Title2' } },
    { id: 3, name: 'David', age: 20 },
  ])).sortBy('name', 'SORT_FLAG_CASE')
````

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
