### PR TITLE
fix(pinia-orm): @OnDelete on same model attrs leads to undefined error

### DIFF
--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -1,8 +1,6 @@
-import type { DefineStoreOptionsBase } from 'pinia'
 import { assert, isArray, isNullish } from '../support/Utils'
 import type { Collection, Element, Item } from '../data/Data'
 import type { MutatorFunctions, Mutators } from '../types'
-import type { DataStore, DataStoreState } from '../composables/useDataStore'
 import type { ModelConfigOptions } from '../store/Store'
 import { config } from '../store/Config'
 import type { Attribute } from './attributes/Attribute'

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -163,6 +163,7 @@ export class Model {
    */
   protected static initializeSchema(): void {
     this.schemas[this.entity] = {}
+    this.fieldsOnDelete[this.entity] = this.fieldsOnDelete[this.entity] ?? {}
 
     const registry = {
       ...this.fields(),
@@ -175,8 +176,9 @@ export class Model {
       this.schemas[this.entity][key]
         = typeof attribute === 'function' ? attribute() : attribute
 
-      if (this.fieldsOnDelete[key])
-        this.schemas[this.entity][key] = (this.schemas[this.entity][key] as Relation).onDelete(this.fieldsOnDelete[key])
+      console.log(this.fieldsOnDelete[this.entity][key])
+      if (this.fieldsOnDelete[this.entity][key])
+        this.schemas[this.entity][key] = (this.schemas[this.entity][key] as Relation).onDelete(this.fieldsOnDelete[this.entity][key])
     }
   }
 
@@ -204,7 +206,8 @@ export class Model {
     key: string,
     mode: deleteModes,
   ): M {
-    this.fieldsOnDelete[key] = mode
+    this.fieldsOnDelete[this.entity] = this.fieldsOnDelete[this.entity] ?? {}
+    this.fieldsOnDelete[this.entity][key] = mode
 
     return this
   }

--- a/packages/pinia-orm/tests/feature/repository/delete_with_relations.spec.ts
+++ b/packages/pinia-orm/tests/feature/repository/delete_with_relations.spec.ts
@@ -71,6 +71,7 @@ describe('feature/repository/delete_with_relations', () => {
       static entity = 'roles'
 
       @Num(0) declare id: number
+      @Str('') declare posts: string
       declare pivot: RoleUser
     }
 
@@ -154,9 +155,9 @@ describe('feature/repository/delete_with_relations', () => {
         1: { id: 1, name: 'John Doe' },
       },
       roles: {
-        1: { id: 1 },
-        2: { id: 2 },
-        4: { id: 4 },
+        1: { id: 1, posts: '' },
+        2: { id: 2, posts: '' },
+        4: { id: 4, posts: '' },
       },
       roleUser: {
         '[1,1]': { role_id: 1, user_id: 1, level: 1 },


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #748

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If you have the name attributes with diffrent behaviour and using `onDelete` it causes an error because the attribute names are registered on model level instead for the entity itself.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
