### PR TITLE
refactor!: make `all()` not accessible from query

### DIFF
--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -395,7 +395,7 @@ export class Query<M extends Model = Model> {
    * Get all models from the store. The difference with the `get` is that this
    * method will not process any query chain. It'll always retrieve all models.
    */
-  all(): Collection<M> {
+  private all(): Collection<M> {
     const data = this.commit('all')
 
     const collection = [] as Collection<M>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

related #774 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since `all()` ignores the query builder it shouldn't be able to be called from the query builder. This helps to have more exspected results so that `useRepo(User).all()` is correct but `useRepo(User).query().all()` not.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
