### PR TITLE
fix(pinia-orm): `new` doesnt fire creating or created hook

### DIFF
--- a/docs/content/2.api/4.repository/new.md
+++ b/docs/content/2.api/4.repository/new.md
@@ -1,0 +1,25 @@
+---
+title: 'new()'
+description: 'Create and persist model with default values.'
+---
+
+# `new()`
+
+## Usage
+
+````ts
+import { useRepo } from 'pinia-orm'
+import User from './models/User'
+
+const userRepo = useRepo(User)
+
+// Make a model with default values
+userRepo.new()
+
+````
+
+## Typescript Declarations
+
+````ts
+function new(): Model | null
+````

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -689,9 +689,15 @@ export class Query<M extends Model = Model> {
   /**
    * Create and persist model with default values.
    */
-  new(): M {
+  new(): M | null {
     const model = this.hydrate({})
+    const isCreating = model.$self().creating(model)
+    const isSaving = model.$self().saving(model)
+    if (isCreating === false || isSaving === false)
+      return null
 
+    model.$self().created(model)
+    model.$self().saved(model)
     this.commit('insert', this.compile(model))
 
     return model

--- a/packages/pinia-orm/src/repository/Repository.ts
+++ b/packages/pinia-orm/src/repository/Repository.ts
@@ -350,7 +350,7 @@ export class Repository<M extends Model = Model> {
   /**
    * Create and persist model with default values.
    */
-  new(): M {
+  new(): M | null {
     return this.query().new()
   }
 

--- a/packages/pinia-orm/tests/feature/hooks/created.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/created.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { Model, useRepo } from '../../../src'
-import { Num, Str } from '../../../src/decorators'
-import { assertState } from '../../helpers'
+import { Num, Str, Uid } from '../../../src/decorators'
+import { assertState, mockUid } from '../../helpers'
 
 describe('feature/hooks/created', () => {
   it('does nothing when passing in an empty array', () => {
@@ -57,6 +57,34 @@ describe('feature/hooks/created', () => {
       users: {
         1: { id: 1, name: 'John Doe', age: 30 },
         2: { id: 2, name: 'John Doe 2', age: 40 },
+      },
+    })
+  })
+
+  it('is able to change values with new method', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Uid() declare id: string
+      @Str('') declare name: string
+      @Num(0) declare age: number
+
+      static created(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    mockUid(['uid1'])
+
+    const createdMethod = vi.spyOn(User, 'created')
+
+    useRepo(User).new()
+
+    expect(createdMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {
+        uid1: { id: 'uid1', name: 'John', age: 0 },
       },
     })
   })

--- a/packages/pinia-orm/tests/feature/hooks/creating.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/creating.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { Model, useRepo } from '../../../src'
-import { Num, Str } from '../../../src/decorators'
-import { assertState } from '../../helpers'
+import { Num, Str, Uid } from '../../../src/decorators'
+import { assertState, mockUid } from '../../helpers'
 
 describe('feature/hooks/creating', () => {
   it('does nothing when passing in an empty array', () => {
@@ -84,5 +84,30 @@ describe('feature/hooks/creating', () => {
     assertState({
       users: {},
     })
+  })
+
+  it('is stopping record to be saved with new method', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Uid() declare id: string
+      @Str('') declare name: string
+      @Num(0) declare age: number
+
+      static creating(model: Model) {
+        model.name = 'John'
+        return false
+      }
+    }
+
+    mockUid(['uid1'])
+
+    const creatingMethod = vi.spyOn(User, 'creating')
+
+    useRepo(User).new()
+
+    expect(creatingMethod).toHaveBeenCalledOnce()
+
+    assertState({})
   })
 })

--- a/packages/pinia-orm/tests/feature/hooks/saved.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/saved.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { Model, useRepo } from '../../../src'
-import { Num, Str } from '../../../src/decorators'
-import { assertState } from '../../helpers'
+import {Num, Str, Uid} from '../../../src/decorators'
+import {assertState, mockUid} from '../../helpers'
 
 describe('feature/hooks/saved', () => {
   it('does nothing when passing in an empty array', () => {
@@ -49,6 +49,34 @@ describe('feature/hooks/saved', () => {
     assertState({
       users: {
         1: { id: 1, name: 'John Doe', age: 30 },
+      },
+    })
+  })
+
+  it('is able to change values with new method', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Uid() declare id: string
+      @Str('') declare name: string
+      @Num(0) declare age: number
+
+      static saved(model: Model) {
+        model.name = 'John'
+      }
+    }
+
+    mockUid(['uid1'])
+
+    const savedMethod = vi.spyOn(User, 'saved')
+
+    useRepo(User).new()
+
+    expect(savedMethod).toHaveBeenCalledOnce()
+
+    assertState({
+      users: {
+        uid1: { id: 'uid1', name: 'John', age: 0 },
       },
     })
   })

--- a/packages/pinia-orm/tests/feature/hooks/saved.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/saved.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { Model, useRepo } from '../../../src'
-import {Num, Str, Uid} from '../../../src/decorators'
-import {assertState, mockUid} from '../../helpers'
+import { Num, Str, Uid } from '../../../src/decorators'
+import { assertState, mockUid } from '../../helpers'
 
 describe('feature/hooks/saved', () => {
   it('does nothing when passing in an empty array', () => {

--- a/packages/pinia-orm/tests/feature/hooks/saving.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/saving.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { Element } from '../../../src'
 import { BelongsTo as BelongsToClass, Model, useRepo } from '../../../src'
-import {Attr, BelongsTo, Num, Str, Uid} from '../../../src/decorators'
-import {assertState, mockUid} from '../../helpers'
+import { Attr, BelongsTo, Num, Str, Uid } from '../../../src/decorators'
+import { assertState, mockUid } from '../../helpers'
 
 describe('feature/hooks/saving', () => {
   it('does nothing when passing in an empty array', () => {

--- a/packages/pinia-orm/tests/feature/hooks/saving.spec.ts
+++ b/packages/pinia-orm/tests/feature/hooks/saving.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { Element } from '../../../src'
 import { BelongsTo as BelongsToClass, Model, useRepo } from '../../../src'
-import { Attr, BelongsTo, Num, Str } from '../../../src/decorators'
-import { assertState } from '../../helpers'
+import {Attr, BelongsTo, Num, Str, Uid} from '../../../src/decorators'
+import {assertState, mockUid} from '../../helpers'
 
 describe('feature/hooks/saving', () => {
   it('does nothing when passing in an empty array', () => {
@@ -105,5 +105,30 @@ describe('feature/hooks/saving', () => {
     assertState({
       users: {},
     })
+  })
+
+  it('is stopping record to be saved with new method', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Uid() declare id: string
+      @Str('') declare name: string
+      @Num(0) declare age: number
+
+      static saving(model: Model) {
+        model.name = 'John'
+        return false
+      }
+    }
+
+    mockUid(['uid1'])
+
+    const savingMethod = vi.spyOn(User, 'saving')
+
+    useRepo(User).new()
+
+    expect(savingMethod).toHaveBeenCalledOnce()
+
+    assertState({})
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #801

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
