### PR TITLE
perf(pinia-orm): Querying models with belongsToMany are slow

### DIFF
--- a/packages/pinia-orm/tests/performance/save_belongs_to_many_relation.spec.ts
+++ b/packages/pinia-orm/tests/performance/save_belongs_to_many_relation.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { Model, useRepo } from '../../src'
+import { Attr, BelongsToMany, Num, Str } from '../../src/decorators'
+
+describe('performance/save_belongs_to_many_relation.spec', () => {
+  class Role extends Model {
+    static entity = 'roles'
+
+    @Num(0) declare id: number
+    declare pivot: RoleUser
+  }
+
+  class RoleUser extends Model {
+    static entity = 'roleUser'
+
+    static primaryKey = ['role_id', 'user_id']
+
+    @Attr(null) role_id!: number | null
+    @Attr(null) user_id!: number | null
+    @Attr(null) level!: number | null
+  }
+
+  class User extends Model {
+    static entity = 'users'
+
+    @Num(0) id!: number
+    @Str('') name!: string
+
+    @BelongsToMany(() => Role, () => RoleUser, 'user_id', 'role_id')
+    roles!: Role
+  }
+
+  it('saves data with bleongs to many relation within decent time', () => {
+    const userRepo = useRepo(User)
+
+    const users = []
+
+    for (let i = 1; i <= 500; i++) {
+      users.push({
+        id: i,
+        name: `Username ${i}`,
+        roles: [{ id: i, title: `Title ${i}` }],
+      })
+      users.push({
+        id: i + 1,
+        name: `Username ${i}`,
+        roles: [{ id: i, title: `Title ${i}` }],
+      })
+    }
+
+    console.time('time')
+    userRepo.save(users)
+    console.timeEnd('time')
+    console.log('Get Speed test for 1k saved items and 5 queries')
+    console.time('get(): with cache')
+    const timeStart = performance.now()
+    for (let i = 1; i <= 5; i++) {
+      console.time(`time query ${i}`)
+      userRepo.useCache().with('roles').get()
+      console.timeEnd(`time query ${i}`)
+    }
+    expect(userRepo.cache()?.size).toBe(1)
+
+    const useCacheTime = performance.now()
+    console.timeEnd('get(): with cache')
+    console.time('get(): without cache')
+    for (let i = 1; i <= 5; i++) {
+      console.time(`time query without ${i}`)
+      userRepo.with('roles').get()
+      console.timeEnd(`time query without ${i}`)
+    }
+    const useWtihoutCacheTime = performance.now()
+    console.timeEnd('get(): without cache')
+    console.log(`Time with Cache ${useCacheTime - timeStart}, without: ${useWtihoutCacheTime - useCacheTime}`)
+
+    expect(useCacheTime - timeStart).toBeLessThan(useWtihoutCacheTime - useCacheTime)
+  })
+})


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #823

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Reduced the number of queries for `belongsToMany` improving speed by over 70%-80%

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
