### PR TITLE
feat(pinia-orm): Support of composite key for some relations

### DIFF
--- a/docs/content/1.guide/3.relationships/1.getting-started.md
+++ b/docs/content/1.guide/3.relationships/1.getting-started.md
@@ -41,6 +41,40 @@ Pinia ORM provides a variety of relationship attributes. Please see correspondin
 - [One to One](/guide/relationships/one-to-one.md)
 - [One to Many](/guide/relationships/one-to-many.md)
 
+### Composite Key support
+
+The relations `hasOne`, `belongsTo` & `hasMany` are also supporting composite keys if you have models with combined primary key.
+So you can define something like this:
+```js
+class User extends Model {
+  static entity = 'users'
+
+  static primaryKey = ['id', 'secondId']
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      secondId: this.attr(null),
+      name: this.string(''),
+      posts: this.hasMany(Post, ['userId', 'userSecondId'])
+    }
+  }
+}
+
+class Post extends Model {
+  static entity = 'posts'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      userId: this.attr(null),
+      userSecondId: this.attr(null),
+      title: this.string('')
+    }
+  }
+}
+```
+
 ## Loading Relationships
 
 Relationships must be "eagerly loaded" by adding the `with(...)` method to your repository's query chain. For example, let's say your `User` model has the following relationship to the `Post` model:
@@ -203,6 +237,16 @@ useRepo(User).withAllRecursive().get()
 
 // As above, limiting to 2 levels deep.
 useRepo(User).withAllRecursive(2).get()
+```
+
+### Loading Nested Relationships
+
+To load nested relationships, you may pass constraints to the 2nd argument. For example, let's load all of the book's authors and all of the author's personal contacts:
+
+```js
+const books = useRepo(Book).with('author', (query) => {
+  query.with('contacts')
+}).get()
 ```
 
 ## Inserting Relationships

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/belongs-to.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/belongs-to.md
@@ -47,7 +47,7 @@ class User extends Model {
 ````ts
 function belongsTo(
   related: typeof Model,
-  foreignKey: string,
-  ownerKey?: string,
+  foreignKey: string | string[],
+  ownerKey?: string | string[],
 ): BelongsTo
 ````

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/has-many.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/has-many.md
@@ -45,7 +45,7 @@ class Post extends Model {
 ````ts
 function hasMany(
   related: typeof Model,
-  foreignKey: string,
-  localKey?: string,
+  foreignKey: string | string[],
+  localKey?: string | string[],
 ): HasMany 
 ````

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/has-one.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/has-one.md
@@ -45,7 +45,7 @@ class User extends Model {
 ````ts
 function hasOne(
   related: typeof Model,
-  foreignKey: string,
-  localKey?: string,
+  foreignKey: string | string[],
+  localKey?: string | string[],
 ): HasOne
 ````

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -27,6 +27,7 @@ export type ModelFields = Record<string, Attribute>
 export type ModelSchemas = Record<string, ModelFields>
 export type ModelRegistries = Record<string, ModelRegistry>
 export type ModelRegistry = Record<string, () => Attribute>
+export type PrimaryKey = string | string[]
 
 export interface ModelOptions {
   config?: ModelConfigOptions
@@ -326,12 +327,12 @@ export class Model {
    */
   static hasOne(
     related: typeof Model,
-    foreignKey: string,
-    localKey?: string,
+    foreignKey: PrimaryKey,
+    localKey?: PrimaryKey,
   ): HasOne {
     const model = this.newRawInstance()
 
-    localKey = localKey ?? model.$getLocalKey()
+    localKey = localKey ?? model.$getKeyName()
 
     return new HasOne(model, related.newRawInstance(), foreignKey, localKey)
   }
@@ -341,12 +342,12 @@ export class Model {
    */
   static belongsTo(
     related: typeof Model,
-    foreignKey: string,
-    ownerKey?: string,
+    foreignKey: PrimaryKey,
+    ownerKey?: PrimaryKey,
   ): BelongsTo {
     const instance = related.newRawInstance()
 
-    ownerKey = ownerKey ?? instance.$getLocalKey()
+    ownerKey = ownerKey ?? instance.$getKeyName()
 
     return new BelongsTo(this.newRawInstance(), instance, foreignKey, ownerKey)
   }
@@ -387,12 +388,12 @@ export class Model {
    */
   static hasMany(
     related: typeof Model,
-    foreignKey: string,
-    localKey?: string,
+    foreignKey: PrimaryKey,
+    localKey?: PrimaryKey,
   ): HasMany {
     const model = this.newRawInstance()
 
-    localKey = localKey ?? model.$getLocalKey()
+    localKey = localKey ?? model.$getKeyName()
 
     return new HasMany(model, related.newRawInstance(), foreignKey, localKey)
   }

--- a/packages/pinia-orm/src/model/attributes/relations/HasMany.ts
+++ b/packages/pinia-orm/src/model/attributes/relations/HasMany.ts
@@ -2,7 +2,7 @@ import type { Schema as NormalizrSchema } from '@pinia-orm/normalizr'
 import type { Schema } from '../../../schema/Schema'
 import type { Collection, Element } from '../../../data/Data'
 import type { Query } from '../../../query/Query'
-import type { Model } from '../../Model'
+import type { Model, PrimaryKey } from '../../Model'
 import type { Dictionary } from './Relation'
 import { Relation } from './Relation'
 
@@ -10,12 +10,12 @@ export class HasMany extends Relation {
   /**
    * The foreign key of the parent model.
    */
-  foreignKey: string
+  foreignKey: PrimaryKey
 
   /**
    * The local key of the parent model.
    */
-  localKey: string
+  localKey: PrimaryKey
 
   /**
    * Create a new has-many relation instance.
@@ -23,8 +23,8 @@ export class HasMany extends Relation {
   constructor(
     parent: Model,
     related: Model,
-    foreignKey: string,
-    localKey: string,
+    foreignKey: PrimaryKey,
+    localKey: PrimaryKey,
   ) {
     super(parent, related)
     this.foreignKey = foreignKey
@@ -49,14 +49,22 @@ export class HasMany extends Relation {
    * Attach the relational key to the given relation.
    */
   attach(record: Element, child: Element): void {
-    child[this.foreignKey] = record[this.localKey]
+    this.compositeKeyMapper(
+      this.foreignKey,
+      this.localKey,
+      (foreignKey, localKey) => child[foreignKey] = record[localKey],
+    )
   }
 
   /**
    * Set the constraints for an eager load of the relation.
    */
   addEagerConstraints(query: Query, models: Collection): void {
-    query.whereIn(this.foreignKey, this.getKeys(models, this.localKey))
+    this.compositeKeyMapper(
+      this.foreignKey,
+      this.localKey,
+      (foreignKey, localKey) => query.whereIn(foreignKey, this.getKeys(models, localKey)),
+    )
   }
 
   /**
@@ -66,7 +74,7 @@ export class HasMany extends Relation {
     const dictionary = this.buildDictionary(query.get(false))
 
     models.forEach((model) => {
-      const key = model[this.localKey]
+      const key = model[this.getKey(this.localKey)]
 
       dictionary[key]
         ? model.$setRelation(relation, dictionary[key])
@@ -79,7 +87,8 @@ export class HasMany extends Relation {
    */
   protected buildDictionary(results: Collection): Dictionary {
     return this.mapToDictionary(results, (result) => {
-      return [result[this.foreignKey], result]
+      const key = this.getKey(this.foreignKey)
+      return [result[key], result]
     })
   }
 

--- a/packages/pinia-orm/src/model/decorators/attributes/relations/BelongsTo.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/relations/BelongsTo.ts
@@ -1,4 +1,4 @@
-import type { Model } from '../../../Model'
+import type { Model, PrimaryKey } from '../../../Model'
 import type { PropertyDecorator } from '../../Contracts'
 
 /**
@@ -6,8 +6,8 @@ import type { PropertyDecorator } from '../../Contracts'
  */
 export function BelongsTo(
   related: () => typeof Model,
-  foreignKey: string,
-  ownerKey?: string,
+  foreignKey: PrimaryKey,
+  ownerKey?: PrimaryKey,
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()

--- a/packages/pinia-orm/src/model/decorators/attributes/relations/HasMany.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/relations/HasMany.ts
@@ -1,4 +1,4 @@
-import type { Model } from '../../../Model'
+import type { Model, PrimaryKey } from '../../../Model'
 import type { PropertyDecorator } from '../../Contracts'
 
 /**
@@ -6,8 +6,8 @@ import type { PropertyDecorator } from '../../Contracts'
  */
 export function HasMany(
   related: () => typeof Model,
-  foreignKey: string,
-  localKey?: string,
+  foreignKey: PrimaryKey,
+  localKey?: PrimaryKey,
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()

--- a/packages/pinia-orm/src/model/decorators/attributes/relations/HasOne.ts
+++ b/packages/pinia-orm/src/model/decorators/attributes/relations/HasOne.ts
@@ -1,4 +1,4 @@
-import type { Model } from '../../../Model'
+import type { Model, PrimaryKey } from '../../../Model'
 import type { PropertyDecorator } from '../../Contracts'
 
 /**
@@ -6,8 +6,8 @@ import type { PropertyDecorator } from '../../Contracts'
  */
 export function HasOne(
   related: () => typeof Model,
-  foreignKey: string,
-  localKey?: string,
+  foreignKey: PrimaryKey,
+  localKey?: PrimaryKey,
 ): PropertyDecorator {
   return (target, propertyKey) => {
     const self = target.$self()

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -920,7 +920,7 @@ export class Query<M extends Model = Model> {
           }
           case 'set null': {
             if ((relation as HasMany).foreignKey)
-              record[(relation as HasMany).foreignKey] = null
+              record[(relation as HasMany).foreignKey as string] = null
 
             if ((relation as MorphMany).morphId) {
               record[(relation as MorphMany).morphId] = null

--- a/packages/pinia-orm/tests/feature/relations/belongs_to_retrieve_composite.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/belongs_to_retrieve_composite.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { Model, useRepo } from '../../../src'
+import { Attr, BelongsTo, Str } from '../../../src/decorators'
+
+describe('feature/relations/belongs_to_retrieve_composite', () => {
+  Model.clearRegistries()
+  class User extends Model {
+    static entity = 'users'
+
+    static primaryKey = ['id', 'secondId']
+
+    @Attr() declare id: number
+    @Attr() declare secondId: number
+    @Str('') declare name: string
+  }
+
+  class Post extends Model {
+    static entity = 'posts'
+
+    @Attr() declare id: number
+    @Attr() declare userId: number | null
+    @Attr() declare userSecondId: number | null
+    @Str('') declare title: string
+
+    @BelongsTo(() => User, ['userId', 'userSecondId'])
+    declare author: User | null
+  }
+
+  it('can eager load belongs to relation', () => {
+    const userRepo = useRepo(User)
+    const postsRepo = useRepo(Post)
+
+    userRepo.save({ id: 1, secondId: 1, name: 'John Doe' })
+    userRepo.save({ id: 1, secondId: 1, name: 'John Doe' })
+    postsRepo.save({ id: 1, userId: 1, userSecondId: 1, title: 'Title 01' })
+
+    const post = postsRepo.with('author').first()
+
+    expect(post).toBeInstanceOf(Post)
+    expect(post?.author).toBeInstanceOf(User)
+    expect(post).toEqual({
+      id: 1,
+      userId: 1,
+      userSecondId: 1,
+      title: 'Title 01',
+      author: { id: 1, secondId: 1, name: 'John Doe' },
+    })
+  })
+
+  it('can eager load missing relation as `null`', () => {
+    const postsRepo = useRepo(Post)
+
+    postsRepo.save({ id: 1, userId: 1, userSecondId: 1, title: 'Title 01' })
+
+    const post = postsRepo.with('author').first()
+
+    expect(post).toBeInstanceOf(Post)
+    expect(post).toEqual({
+      id: 1,
+      userId: 1,
+      userSecondId: 1,
+      title: 'Title 01',
+      author: null,
+    })
+  })
+
+  it('ignores the relation with the empty foreign key', () => {
+    const userRepo = useRepo(User)
+    const postsRepo = useRepo(Post)
+
+    userRepo.save({ id: 1, secondId: 1, name: 'John Doe' })
+    postsRepo.save({ id: 1, userId: null, userSecondId: null, title: 'Title 01' })
+
+    const post = postsRepo.with('author').first()
+
+    expect(post).toBeInstanceOf(Post)
+    expect(post).toEqual({
+      id: 1,
+      userId: null,
+      userSecondId: null,
+      title: 'Title 01',
+      author: null,
+    })
+  })
+})

--- a/packages/pinia-orm/tests/feature/relations/has_many_retrieve_composite.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/has_many_retrieve_composite.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import { Model, useRepo } from '../../../src'
+import { Attr, HasMany, Str } from '../../../src/decorators'
+import { assertInstanceOf, assertModel } from '../../helpers'
+
+describe('feature/relations/has_many_retrieve_composite', () => {
+  class Post extends Model {
+    static entity = 'posts'
+
+    @Attr() id!: number
+    @Attr() userId!: number
+    @Attr() userSecondId!: number
+    @Str('') title!: string
+  }
+
+  class User extends Model {
+    static entity = 'users'
+    static primaryKey = ['id', 'secondId']
+
+    @Attr() id!: number
+    @Attr() secondId!: number
+    @Str('') name!: string
+
+    @HasMany(() => Post, ['userId', 'userSecondId'])
+      posts!: Post[]
+  }
+
+  it('can eager load has many relation', () => {
+    const postsRepo = useRepo(Post)
+    const usersRepo = useRepo(User)
+
+    postsRepo.save([
+      { id: 1, userSecondId: 1, userId: 1, title: 'Title 01' },
+      { id: 2, userSecondId: 1, userId: 1, title: 'Title 02' },
+    ])
+    usersRepo.save({ id: 1, secondId: 1, name: 'John Doe' })
+
+    const user = usersRepo.with('posts').first()!
+
+    expect(user).toBeInstanceOf(User)
+    assertInstanceOf(user.posts, Post)
+    assertModel(user, {
+      id: 1,
+      secondId: 1,
+      name: 'John Doe',
+      posts: [
+        { id: 1, userId: 1, userSecondId: 1, title: 'Title 01' },
+        { id: 2, userId: 1, userSecondId: 1, title: 'Title 02' },
+      ],
+    })
+  })
+
+  it('can eager load missing relation as empty array', () => {
+    const usersRepo = useRepo(User)
+
+    usersRepo.save({ id: 1, secondId: 1, name: 'John Doe' })
+
+    const user = usersRepo.with('posts').first()!
+
+    expect(user).toBeInstanceOf(User)
+    assertModel(user, {
+      id: 1,
+      secondId: 1,
+      name: 'John Doe',
+      posts: [],
+    })
+  })
+
+  it('can revive "has many" relations', () => {
+    const postsRepo = useRepo(Post)
+    const usersRepo = useRepo(User)
+
+    postsRepo.save([
+      { id: 1, userSecondId: 1, userId: 1, title: 'Title 01' },
+      { id: 2, userSecondId: 1, userId: 1, title: 'Title 02' },
+    ])
+    usersRepo.save({ id: 1, secondId: 1, name: 'John Doe' })
+
+    const schema = {
+      id: 1,
+      secondId: 1,
+      posts: [{ id: 2 }, { id: 1 }],
+    }
+
+    const user = usersRepo.revive(schema)!
+
+    expect(user.posts.length).toBe(2)
+    expect(user.posts[0]).toBeInstanceOf(Post)
+    expect(user.posts[1]).toBeInstanceOf(Post)
+    expect(user.posts[0].id).toBe(2)
+    expect(user.posts[1].id).toBe(1)
+  })
+})

--- a/packages/pinia-orm/tests/feature/relations/has_many_save_custom_key.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/has_many_save_custom_key.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { Model, useRepo } from '../../../src'
 import { Attr, HasMany, Str } from '../../../src/decorators'
@@ -93,5 +93,42 @@ describe('feature/relations/has_many_save_custom_key', () => {
         2: { id: 2, userId: 2, title: 'Title 02' },
       },
     })
+  })
+
+  it('throws an error with wrong key match', () => {
+    class Post extends Model {
+      static entity = 'posts'
+
+      @Attr() declare id: number
+      @Attr() declare userId: number
+      @Attr() declare userSecondId: number
+      @Str('') declare title: string
+    }
+
+    class User extends Model {
+      static entity = 'users'
+      static primaryKey = ['id', 'secondId']
+
+      @Attr() declare id: number
+      @Attr() declare secondId: number
+      @Str('') declare name: string
+
+      @HasMany(() => Post, ['userId', 'userSecondId'], 'id')
+      declare posts: Post[]
+    }
+
+    const usersRepo = useRepo(User)
+
+    expect(() => {
+      usersRepo.save({
+        id: 1,
+        secondId: 2,
+        name: 'John Doe',
+        posts: [
+          { id: 1, title: 'Title 01' },
+          { id: 2, title: 'Title 02' },
+        ],
+      })
+    }).toThrowError()
   })
 })

--- a/packages/pinia-orm/tests/feature/relations/has_one_retrieve_composite.spec.ts
+++ b/packages/pinia-orm/tests/feature/relations/has_one_retrieve_composite.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { Model, useRepo } from '../../../src'
+import { Attr, HasOne, Str } from '../../../src/decorators'
+import { assertModel } from '../../helpers'
+
+describe('feature/relations/has_one_retrieve_composite', () => {
+  class Phone extends Model {
+    static entity = 'phones'
+
+    @Attr() declare id: number
+    @Attr() declare userId: number
+    @Attr() declare userSecondId: number
+    @Str('') declare number: string
+  }
+
+  class User extends Model {
+    static entity = 'users'
+
+    static primaryKey = ['id', 'secondId']
+
+    @Attr() declare id: number
+    @Attr() declare secondId: number
+    @Str('') declare name: string
+
+    @HasOne(() => Phone, ['userId', 'userSecondId'])
+      phone!: Phone | null
+  }
+
+  it('can eager load has one relation', () => {
+    const usersRepo = useRepo(User)
+    const phonesRepo = useRepo(Phone)
+
+    usersRepo.save({ id: 1, secondId: 1, name: 'John Doe' })
+    phonesRepo.save({ id: 1, userId: 1, userSecondId: 1, number: '123-4567-8912' })
+
+    const user = usersRepo.with('phone').first()!
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.phone).toBeInstanceOf(Phone)
+    assertModel(user, {
+      id: 1,
+      secondId: 1,
+      name: 'John Doe',
+      phone: {
+        id: 1,
+        userId: 1,
+        userSecondId: 1,
+        number: '123-4567-8912',
+      },
+    })
+  })
+
+  it('can eager load missing relation as `null`', () => {
+    const usersRepo = useRepo(User)
+
+    usersRepo.save({ id: 1, secondId: 1, name: 'John Doe' })
+
+    const user = usersRepo.with('phone').first()!
+
+    expect(user).toBeInstanceOf(User)
+    assertModel(user, {
+      id: 1,
+      secondId: 1,
+      name: 'John Doe',
+      phone: null,
+    })
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #829

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adding support of composite keys for `belongsTo`, `hasOne` and `hasMany`. So you can do something like this:

````ts
  class Phone extends Model {
    static entity = 'phones'

    @Attr() declare id: number
    @Attr() declare userId: number
    @Attr() declare userSecondId: number
    @Str('') declare number: string
  }

  class User extends Model {
    static entity = 'users'

    static primaryKey = ['id', 'secondId']

    @Attr() declare id: number
    @Attr() declare secondId: number
    @Str('') declare name: string

    @HasOne(() => Phone, ['userId', 'userSecondId'])
      phone!: Phone | null
  }
````

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
