### PR TITLE
perf(pinia-orm): Improve caching for hydrated models

### DIFF
--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -1,6 +1,6 @@
 import type { Pinia } from 'pinia'
 import {
-  assert, compareWithOperator, equals, generateKey,
+  assert, compareWithOperator, generateKey,
   groupBy,
   isArray,
   isEmpty,
@@ -954,6 +954,7 @@ export class Query<M extends Model = Model> {
       // eslint-disable-next-line max-statements-per-line
       if (isDeleting === false) { notDeletableIds.push(currentModel.$getIndexId()) }
       else {
+        this.hydratedDataCache.delete(this.model.$entity() + currentModel.$getIndexId())
         afterHooks.push(() => currentModel.$self().deleted(currentModel))
         this.checkAndDeleteRelations(currentModel)
       }

--- a/packages/pinia-orm/src/repository/Repository.ts
+++ b/packages/pinia-orm/src/repository/Repository.ts
@@ -52,7 +52,7 @@ export class Repository<M extends Model = Model> {
   /**
    * Hydrated models. They are stored to prevent rerendering of child components.
    */
-  hydratedData: Map<string, M>
+  hydratedDataCache: Map<string, M>
 
   /**
    * The model object to be used for the custom repository.
@@ -65,7 +65,7 @@ export class Repository<M extends Model = Model> {
   constructor(database: Database, pinia?: Pinia) {
     this.database = database
     this.pinia = pinia
-    this.hydratedData = new Map()
+    this.hydratedDataCache = new Map<string, M>()
   }
 
   /**
@@ -130,7 +130,7 @@ export class Repository<M extends Model = Model> {
    * Create a new Query instance.
    */
   query(): Query<M> {
-    return new Query(this.database, this.getModel(), this.queryCache, this.hydratedData, this.pinia)
+    return new Query(this.database, this.getModel(), this.queryCache, this.hydratedDataCache, this.pinia)
   }
 
   /**

--- a/packages/pinia-orm/tests/unit/PiniaORM.spec.ts
+++ b/packages/pinia-orm/tests/unit/PiniaORM.spec.ts
@@ -23,8 +23,11 @@ describe('unit/PiniaORM', () => {
       username: 'JD',
     })
 
-    expect(userRepo.find(1)?._meta).toBe(undefined)
-    expect(userRepo.withMeta().find(1)?._meta).toHaveProperty('createdAt')
+    const userMeta = userRepo.find(1)?._meta
+    const userMeta2 = userRepo.withMeta().find(1)?._meta
+
+    expect(userMeta).toBe(undefined)
+    expect(userMeta2).toHaveProperty('createdAt')
   })
 
   it('pass config "model.hidden"', () => {


### PR DESCRIPTION

### 🔗 Linked issue

closes #853

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The hydration cache is almost now the same as the query cache. The hydration caching now doesn't use a deep compare anymore so that the speed will improve significatly for large model opjects. The perfomance should be 20%-80% better.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
