### PR TITLE
feat(pinia-orm): Shared hydration cache & pinia actions triggering repo actions

### DIFF
--- a/packages/pinia-orm/src/cache/SharedHydratedDatakCache.ts
+++ b/packages/pinia-orm/src/cache/SharedHydratedDatakCache.ts
@@ -1,0 +1,3 @@
+import type { Model } from '../model/Model'
+
+export const cache = <M extends Model = Model>() => new Map<string, M>()

--- a/packages/pinia-orm/src/composables/useDataStore.ts
+++ b/packages/pinia-orm/src/composables/useDataStore.ts
@@ -1,14 +1,16 @@
 import type { DefineStoreOptionsBase } from 'pinia'
 import { defineStore } from 'pinia'
 import { useStoreActions } from './useStoreActions'
+import type { Query } from '@/query/Query'
 
 export function useDataStore<S extends DataStoreState, T extends DataStore = DataStore>(
   id: string,
   options: DefineStoreOptionsBase<S, T>,
+  query?: Query,
 ) {
   return defineStore(id, {
     state: () => ({ data: {} } as S),
-    actions: useStoreActions(),
+    actions: useStoreActions(query),
     ...options,
   })
 }

--- a/packages/pinia-orm/src/composables/useRepo.ts
+++ b/packages/pinia-orm/src/composables/useRepo.ts
@@ -27,9 +27,9 @@ export function useRepo(
   try {
     const typeModels = Object.values(repository.getModel().$types())
     if (typeModels.length > 0)
-      typeModels.forEach(typeModel => database.register(typeModel.newRawInstance()))
+      typeModels.forEach(typeModel => repository.database.register(typeModel.newRawInstance()))
     else
-      database.register(repository.getModel())
+      repository.database.register(repository.getModel())
   }
   catch (e) {}
 

--- a/packages/pinia-orm/src/composables/useStoreActions.ts
+++ b/packages/pinia-orm/src/composables/useStoreActions.ts
@@ -1,21 +1,34 @@
 import type { Elements } from '../data/Data'
+import type { Query } from '../query/Query'
 import type { DataStore } from './useDataStore'
 
-export function useStoreActions() {
+export function useStoreActions(query?: Query) {
   return {
-    save(this: DataStore, records: Elements) {
+    save(this: DataStore, records: Elements, triggerQueryAction = true) {
       this.data = { ...this.data, ...records }
+
+      if (triggerQueryAction && query)
+        query.save(Object.values(records))
     },
-    insert(this: DataStore, records: Elements) {
+    insert(this: DataStore, records: Elements, triggerQueryAction = true) {
       this.data = { ...this.data, ...records }
+
+      if (triggerQueryAction && query)
+        query.insert(Object.values(records))
     },
-    update(this: DataStore, records: Elements) {
+    update(this: DataStore, records: Elements, triggerQueryAction = true) {
       this.data = { ...this.data, ...records }
+
+      if (triggerQueryAction && query)
+        query.update(Object.values(records))
     },
-    fresh(this: DataStore, records: Elements) {
+    fresh(this: DataStore, records: Elements, triggerQueryAction = true) {
       this.data = records
+
+      if (triggerQueryAction && query)
+        query.fresh(Object.values(records))
     },
-    destroy(this: DataStore, ids: string[]): void {
+    destroy(this: DataStore, ids: string[], triggerQueryAction = true): void {
       const data: Elements = {}
 
       for (const id in this.data) {
@@ -24,11 +37,14 @@ export function useStoreActions() {
       }
 
       this.data = data
+
+      if (triggerQueryAction && query)
+        query.destroy(ids)
     },
     /**
      * Commit `delete` change to the store.
      */
-    delete(this: DataStore, ids: string[]): void {
+    delete(this: DataStore, ids: string[], triggerQueryAction = true): void {
       const data: Elements = {}
 
       for (const id in this.data) {
@@ -37,9 +53,15 @@ export function useStoreActions() {
       }
 
       this.data = data
+
+      if (triggerQueryAction && query)
+        query.destroy(ids)
     },
-    flush(this: DataStore): void {
+    flush(this: DataStore, _records: Elements, triggerQueryAction = true): void {
       this.data = {}
+
+      if (triggerQueryAction && query)
+        query.flush()
     },
   }
 }

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -161,9 +161,9 @@ export class Query<M extends Model = Model> {
    * Commit a store action and get the data
    */
   protected commit(name: string, payload?: any) {
-    const store = useDataStore(this.model.$baseEntity(), this.model.$piniaOptions())(this.pinia)
+    const store = useDataStore(this.model.$baseEntity(), this.model.$piniaOptions(), this)(this.pinia)
     if (name && typeof store[name] === 'function')
-      store[name](payload)
+      store[name](payload, false)
 
     if (this.cache && ['get', 'all', 'insert', 'flush', 'delete', 'update', 'destroy'].includes(name))
       this.cache.clear()

--- a/packages/pinia-orm/src/repository/Repository.ts
+++ b/packages/pinia-orm/src/repository/Repository.ts
@@ -18,6 +18,7 @@ import { useRepo } from '../composables/useRepo'
 import type { DataStoreState } from '../composables/useDataStore'
 import { useDataStore } from '../composables/useDataStore'
 import { cache } from '../cache/SharedWeakCache'
+import { cache as hydratedDataCache } from '../cache/SharedHydratedDatakCache'
 import type { WeakCache } from '../cache/WeakCache'
 import { config } from '../store/Config'
 
@@ -65,7 +66,7 @@ export class Repository<M extends Model = Model> {
   constructor(database: Database, pinia?: Pinia) {
     this.database = database
     this.pinia = pinia
-    this.hydratedDataCache = new Map<string, M>()
+    this.hydratedDataCache = hydratedDataCache<M>()
   }
 
   /**
@@ -114,7 +115,7 @@ export class Repository<M extends Model = Model> {
    * Returns the pinia store used with this model
    */
   piniaStore<S extends DataStoreState = DataStoreState>() {
-    return useDataStore<S>(this.model.$entity(), this.model.$piniaOptions())(this.pinia)
+    return useDataStore<S>(this.model.$entity(), this.model.$piniaOptions(), this.query())(this.pinia)
   }
 
   /**

--- a/packages/pinia-orm/tests/unit/composables/Use_Collect.spec.ts
+++ b/packages/pinia-orm/tests/unit/composables/Use_Collect.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { Model, useRepo } from '../../../src'
 import { Attr, HasOne, Num, Str } from '../../../src/decorators'
@@ -23,13 +23,17 @@ describe('unit/composables/Collect', () => {
     @Str('') declare title: string
   }
 
-  const userCollection = useCollect(useRepo(User).make([
-    { id: 1, name: 'James', age: 40, post: { id: 1, title: 'Title1' } },
-    { id: 2, name: 'James', age: 30, post: { id: 2, title: 'Title2' } },
-    { id: 3, name: 'David', age: 20 },
-    { id: 4, name: 'john', age: 20 },
-    { id: 5, name: 'Zod', age: 20 },
-  ]))
+  let userCollection: ReturnType<typeof useCollect<User>>
+
+  beforeEach(() => {
+    userCollection = useCollect(useRepo(User).make([
+      { id: 1, name: 'James', age: 40, post: { id: 1, title: 'Title1' } },
+      { id: 2, name: 'James', age: 30, post: { id: 2, title: 'Title2' } },
+      { id: 3, name: 'David', age: 20 },
+      { id: 4, name: 'john', age: 20 },
+      { id: 5, name: 'Zod', age: 20 },
+    ]))
+  })
 
   it('can group records using the "groupBy" modifier', () => {
     const expected = {

--- a/packages/pinia-orm/tests/unit/repository/Repository.spec.ts
+++ b/packages/pinia-orm/tests/unit/repository/Repository.spec.ts
@@ -87,6 +87,14 @@ describe('unit/repository/Repository', () => {
     expect(postRepo.getModel()).toBeInstanceOf(Post)
   })
 
+  it('can trigger cache & hook from the pinia store action', () => {
+    const userRepo = useRepo(User)
+    expect(userRepo.hydratedDataCache.size).toBe(0)
+
+    userRepo.piniaStore().save({ 1: { id: 1, name: 'John' } })
+    expect(userRepo.hydratedDataCache.size).toBe(1)
+  })
+
   it('can access the pinia store', () => {
     const logger = vi.spyOn(console, 'log')
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #1058

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

1. This is adding a shared hydration cache to improve performance accross repositories. 
2. The pinia actions if called directly now also trigger the store actions so hooks & hydration cache is updated

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
