### PR TITLE
docs: Fixed typo on entity name in example

### DIFF
--- a/docs/content/1.guide/3.relationships/2.one-to-one.md
+++ b/docs/content/1.guide/3.relationships/2.one-to-one.md
@@ -24,7 +24,7 @@ class User extends Model {
 }
 
 class Phone extends Model {
-  static entity = 'users'
+  static entity = 'phones'
 
   static fields () {
     return {
@@ -61,7 +61,7 @@ So, we can access the `Phone` model from our `User`. Now, let's define a relatio
 
 ```js
 class Phone extends Model {
-  static entity = 'users'
+  static entity = 'phones'
 
   static fields () {
     return {
@@ -80,7 +80,7 @@ If your parent model does not use `id` as its primary key, or you wish to join t
 
 ```js
 class Phone extends Model {
-  static entity = 'users'
+  static entity = 'phones'
 
   static fields () {
     return {


### PR DESCRIPTION
The `Phone` model was using `users` as the entity name. The same being used for the `User` model.
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `Phone` model was using `users` as the entity name. The same being used for the `User` model.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
