### PR TITLE
 chore(pinia-orm): Remove deprecated tsconfig `suppressImplicitAnyIndexErrors`

### DIFF
--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -66,6 +66,7 @@
     "@antfu/eslint-config": "^0.38.2",
     "@pinia/testing": "^0.0.15",
     "@size-limit/preset-small-lib": "^8.2.4",
+    "@types/node": "^18.16.2",
     "@types/prettier": "^2.7.2",
     "@types/uuid": "^9.0.1",
     "@vitest/coverage-c8": "^0.29.8",

--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -83,7 +83,7 @@
     "size-limit": "^8.2.4",
     "std-env": "^3.3.2",
     "tsup": "^6.7.0",
-    "typescript": "^5.0.3",
+    "typescript": "^5.0.4",
     "unbuild": "^1.1.2",
     "uuid": "^9.0.0",
     "vite": "^4.2.1",

--- a/packages/pinia-orm/src/composables/collection/useGroupBy.ts
+++ b/packages/pinia-orm/src/composables/collection/useGroupBy.ts
@@ -1,7 +1,7 @@
 /**
  * The useGroupBy method groups the collection's items by a given key.
  */
-export function useGroupBy<T>(models: T[], fields: string[] | string): Record<string, T[]> {
+export function useGroupBy<T extends Record<string, any>>(models: T[], fields: string[] | string): Record<string, T[]> {
   const grouped: Record<string, T[]> = {}
   const props = Array.isArray(fields) ? fields : [fields]
 

--- a/packages/pinia-orm/src/composables/collection/useSortBy.ts
+++ b/packages/pinia-orm/src/composables/collection/useSortBy.ts
@@ -7,7 +7,7 @@ export type sorting<T> = ((record: T) => any) | string | [string, 'asc' | 'desc'
  * Creates an array of elements, sorted in specified order by the results
  * of running each element in a collection thru each iteratee.
  */
-export function useSortBy<T>(collection: T[], sort: sorting<T>, flags?: SortFlags): T[] {
+export function useSortBy<T extends Record<string, any>>(collection: T[], sort: sorting<T>, flags?: SortFlags): T[] {
   const directions = []
   const iteratees = []
 

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -104,12 +104,12 @@ export class Model {
   /**
    * Behaviour for relational fields on delete.
    */
-  static fieldsOnDelete = {}
+  static fieldsOnDelete: Record<string, any> = {}
 
   /**
    * Original model data.
    */
-  protected static original = {}
+  protected static original: Record<string, any> = {}
 
   /**
    * The schema for the model. It contains the result of the `fields`
@@ -138,7 +138,7 @@ export class Model {
   /**
    * The casts for the model.
    */
-  protected static fieldCasts = {}
+  protected static fieldCasts: Record<string, any> = {}
 
   /**
    * The array of booted models.

--- a/packages/pinia-orm/src/model/attributes/relations/BelongsToMany.ts
+++ b/packages/pinia-orm/src/model/attributes/relations/BelongsToMany.ts
@@ -100,7 +100,7 @@ export class BelongsToMany extends Relation {
       .whereIn(this.relatedPivotKey, this.getKeys(relatedModels, this.relatedKey))
       .whereIn(this.foreignPivotKey, this.getKeys(models, this.parentKey))
       .groupBy(this.foreignPivotKey, this.relatedPivotKey)
-      .get()
+      .get<'group'>()
 
     models.forEach((parentModel) => {
       const relationResults: Model[] = []

--- a/packages/pinia-orm/src/model/attributes/relations/MorphToMany.ts
+++ b/packages/pinia-orm/src/model/attributes/relations/MorphToMany.ts
@@ -108,7 +108,7 @@ export class MorphToMany extends Relation {
       .whereIn(this.relatedId, this.getKeys(relatedModels, this.relatedKey))
       .whereIn(this.morphId, this.getKeys(models, this.parentKey))
       .groupBy(this.morphId, this.relatedId, this.morphType)
-      .get()
+      .get<'group'>()
 
     models.forEach((parentModel) => {
       const relationResults: Model[] = []

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -744,7 +744,7 @@ export class Query<M extends Model = Model> {
 
     if (Object.values(modelTypes).length > 0 || isChildEntity) {
       const modelTypesKeys = Object.keys(modelTypes)
-      const recordsByTypes = {}
+      const recordsByTypes: Record<string, Element> = {}
       records = isArray(records) ? records : [records]
 
       records.forEach((record: Element) => {
@@ -939,7 +939,7 @@ export class Query<M extends Model = Model> {
         const relationIds = models.map((relation: M) => {
           return relation[relation.$getLocalKey()]
         })
-        const record = {}
+        const record: Record<string, any> = {}
 
         if (relation instanceof BelongsToMany) {
           this.newQuery(relation.pivot.$entity()).where(relation.foreignPivotKey, model[model.$getLocalKey()]).delete()

--- a/packages/pinia-orm/src/support/Utils.ts
+++ b/packages/pinia-orm/src/support/Utils.ts
@@ -1,3 +1,5 @@
+import { Element } from '@'
+
 interface SortableArray<T> {
   criteria: any[]
   index: number
@@ -63,7 +65,7 @@ export function size(collection: any[] | object): number {
  * Creates an array of elements, sorted in specified order by the results
  * of running each element in a collection thru each iteratee.
  */
-export function orderBy<T>(
+export function orderBy<T extends Element>(
   collection: T[],
   iteratees: (((record: T) => any) | string)[],
   directions: string[],
@@ -177,11 +179,11 @@ function compareAscending(value: any, other: any, flags: SortFlags): number {
  * Creates an object composed of keys generated from the results of running
  * each element of collection through iteratee.
  */
-export function groupBy<T>(
+export function groupBy<T extends Element>(
   collection: T[],
   iteratee: (record: T) => string,
 ): { [key: string]: T[] } {
-  return collection.reduce((records, record) => {
+  return collection.reduce((records: Record<string, any>, record) => {
     const key = iteratee(record)
 
     if (records[key] === undefined)
@@ -243,7 +245,7 @@ export function generateKey(key: string, params?: any): string {
 /**
  * Get a value based on a dot-notation key.
  */
-export function getValue(obj: Object, keys: string | string[]): any {
+export function getValue(obj: Record<string, any>, keys: string | string[]): any {
   keys = (typeof keys === 'string') ? keys.split('.') : keys
   const key = keys.shift() as string
   // eslint-disable-next-line no-prototype-builtins

--- a/packages/pinia-orm/src/support/Utils.ts
+++ b/packages/pinia-orm/src/support/Utils.ts
@@ -1,4 +1,4 @@
-import { Element } from '@'
+import type { Element } from '@'
 
 interface SortableArray<T> {
   criteria: any[]
@@ -237,9 +237,7 @@ export function generateKey(key: string, params?: any): string {
   // If the window object exists, we can assume this code is running in a browser.
   return typeof process === 'undefined'
     ? btoa(stringifiedKey)
-    : Buffer !== undefined
-      ? Buffer.from(stringifiedKey, 'utf8').toString('base64')
-      : stringifiedKey
+    : stringifiedKey
 }
 
 /**

--- a/packages/pinia-orm/tsconfig.json
+++ b/packages/pinia-orm/tsconfig.json
@@ -4,7 +4,6 @@
     "baseUrl": ".",
     "rootDir": ".",
     "outDir": "dist",
-    "suppressImplicitAnyIndexErrors": true,
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
     "module": "esnext",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ importers:
         version: 3.3.2(@types/node@18.16.2)(eslint@8.37.0)(rollup@3.20.2)(typescript@5.0.3)
       pinia:
         specifier: ^2.0.33
-        version: 2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.3)(vue@3.2.47)
+        version: 2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.4)(vue@3.2.47)
       pinia-orm:
         specifier: ^1.0.0
         version: link:../pinia-orm
@@ -156,7 +156,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^0.38.2
-        version: 0.38.2(eslint@8.37.0)(typescript@5.0.3)
+        version: 0.38.2(eslint@8.37.0)(typescript@5.0.4)
       '@pinia/testing':
         specifier: ^0.0.15
         version: 0.0.15(@vue/composition-api@1.7.1)(pinia@2.0.33)(vue@3.2.47)
@@ -195,13 +195,13 @@ importers:
         version: 9.1.0
       mkdist:
         specifier: ^1.2.0
-        version: 1.2.0(typescript@5.0.3)
+        version: 1.2.0(typescript@5.0.4)
       nanoid:
         specifier: ^4.0.2
         version: 4.0.2
       pinia:
         specifier: ^2.0.33
-        version: 2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.3)(vue@3.2.47)
+        version: 2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.4)(vue@3.2.47)
       prettier:
         specifier: ^2.8.7
         version: 2.8.7
@@ -213,10 +213,10 @@ importers:
         version: 3.1.1
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.3)
+        version: 6.7.0(typescript@5.0.4)
       typescript:
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.4
+        version: 5.0.4
       unbuild:
         specifier: ^1.1.2
         version: 1.1.2
@@ -248,13 +248,13 @@ packages:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.17
 
-  /@antfu/eslint-config-basic@0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3):
+  /@antfu/eslint-config-basic@0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-yyC7mlQ+p2Mu7TXOj0u/NojYXBjjAyJJDNbC1NM3e3KZdNZxi7mX31kb7FcdB3SMiaKIkKC3Yy3SAsajkYpVMg==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
       eslint: 8.37.0
-      eslint-plugin-antfu: 0.38.2(eslint@8.37.0)(typescript@5.0.3)
+      eslint-plugin-antfu: 0.38.2(eslint@8.37.0)(typescript@5.0.4)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.37.0)
       eslint-plugin-html: 7.1.0
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)
@@ -277,18 +277,18 @@ packages:
       - typescript
     dev: true
 
-  /@antfu/eslint-config-ts@0.38.2(eslint@8.37.0)(typescript@5.0.3):
+  /@antfu/eslint-config-ts@0.38.2(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-I4F8a9oJvTqd6/LLG4b6fhR1qNjEgVNdY8kuILxDV1vacwPpwQp00FfdN1LsjwBIvOQPtBh7KoG6HHep8D9YqQ==}
     peerDependencies:
       eslint: '>=7.4.0'
       typescript: '>=3.9'
     dependencies:
-      '@antfu/eslint-config-basic': 0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
+      '@antfu/eslint-config-basic': 0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
       eslint: 8.37.0
-      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.37.0)(typescript@5.0.3)
-      typescript: 5.0.3
+      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -296,13 +296,13 @@ packages:
       - supports-color
     dev: true
 
-  /@antfu/eslint-config-vue@0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3):
+  /@antfu/eslint-config-vue@0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-YzLixISzgB1szc7++UwK45R5iKSMzo/f4DSWZOMNHWQb/qApjlaSDG5xBTRSPo57Yvm7pvrC8gQ10XfgFuCb6g==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-basic': 0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3)
-      '@antfu/eslint-config-ts': 0.38.2(eslint@8.37.0)(typescript@5.0.3)
+      '@antfu/eslint-config-basic': 0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
+      '@antfu/eslint-config-ts': 0.38.2(eslint@8.37.0)(typescript@5.0.4)
       eslint: 8.37.0
       eslint-plugin-vue: 9.10.0(eslint@8.37.0)
       local-pkg: 0.4.3
@@ -316,14 +316,14 @@ packages:
       - typescript
     dev: true
 
-  /@antfu/eslint-config@0.38.2(eslint@8.37.0)(typescript@5.0.3):
+  /@antfu/eslint-config@0.38.2(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-JOWWCGSS3TSGVA9W6sN2WLD6bvCloENgbW1RpHoPfbZxqdK1phFrUt1wNQ43VHiBr9YGX/mmqCO+meIPzqBpiA==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-vue': 0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
+      '@antfu/eslint-config-vue': 0.38.2(@typescript-eslint/eslint-plugin@5.57.0)(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
       eslint: 8.37.0
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.37.0)
       eslint-plugin-html: 7.1.0
@@ -2161,7 +2161,7 @@ packages:
     resolution: {integrity: sha512-ifgA9PO/jmPlK1e/HtkrZa7OMSL8EUOpo8Z1O5vNLRr/OZ42kKGEaY1NbIoCz6dIf/pbkATTNHJmcrlPCo3zSA==}
     dependencies:
       '@nuxt/kit': 3.3.2(rollup@3.20.2)
-      pinia: 2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.3)(vue@3.2.47)
+      pinia: 2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.4)(vue@3.2.47)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - rollup
@@ -2175,7 +2175,7 @@ packages:
     peerDependencies:
       pinia: '>=2.0.31'
     dependencies:
-      pinia: 2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.3)(vue@3.2.47)
+      pinia: 2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.4)(vue@3.2.47)
       vue-demi: 0.13.11(@vue/composition-api@1.7.1)(vue@3.2.47)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -2655,7 +2655,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3):
+  /@typescript-eslint/eslint-plugin@5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2667,18 +2667,18 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.4.0
-      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
       '@typescript-eslint/scope-manager': 5.57.0
-      '@typescript-eslint/type-utils': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/type-utils': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.37.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.5.0
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2723,7 +2723,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.57.0(eslint@8.37.0)(typescript@5.0.3):
+  /@typescript-eslint/parser@5.57.0(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2735,10 +2735,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.57.0
       '@typescript-eslint/types': 5.57.0
-      '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.37.0
-      typescript: 5.0.3
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2799,7 +2799,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@5.57.0(eslint@8.37.0)(typescript@5.0.3):
+  /@typescript-eslint/type-utils@5.57.0(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2809,12 +2809,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.37.0
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2871,7 +2871,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.57.0(typescript@5.0.3):
+  /@typescript-eslint/typescript-estree@5.57.0(typescript@5.0.4):
     resolution: {integrity: sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2886,8 +2886,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2932,7 +2932,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.57.0(eslint@8.37.0)(typescript@5.0.3):
+  /@typescript-eslint/utils@5.57.0(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2943,7 +2943,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.57.0
       '@typescript-eslint/types': 5.57.0
-      '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.0.4)
       eslint: 8.37.0
       eslint-scope: 5.1.1
       semver: 7.5.0
@@ -5295,7 +5295,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
       debug: 3.2.7
       eslint: 8.37.0
       eslint-import-resolver-node: 0.3.7
@@ -5303,10 +5303,10 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-antfu@0.38.2(eslint@8.37.0)(typescript@5.0.3):
+  /eslint-plugin-antfu@0.38.2(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-Fv4FxkkGsQ55Bw6u8GWhOuWTeiAxSWWH87rXzM0CSXYs4ql55tNuWvn+f9bWhPv1Q6eudr6DRuXuABCsrV0xlg==}
     dependencies:
-      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -5446,7 +5446,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -5469,7 +5469,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.37.0)(typescript@5.0.3):
+  /eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.37.0)(typescript@5.0.4):
     resolution: {integrity: sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -5482,8 +5482,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
       eslint: 8.37.0
     transitivePeerDependencies:
       - supports-color
@@ -5699,7 +5699,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
       eslint: 8.37.0
       eslint-rule-composer: 0.3.0
     dev: true
@@ -8338,29 +8338,6 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /mkdist@1.2.0(typescript@5.0.3):
-    resolution: {integrity: sha512-UTqu/bXmIk/+VKNVgufAeMyjUcNy1dn9Bl7wL1zZlCKVrpDgj/VllmZBeh3ZCC/2HWqUrt6frNFTKt9TRZbNvQ==}
-    hasBin: true
-    peerDependencies:
-      sass: ^1.60.0
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      sass:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      defu: 6.1.2
-      esbuild: 0.17.14
-      fs-extra: 11.1.1
-      globby: 13.1.3
-      jiti: 1.18.2
-      mlly: 1.2.0
-      mri: 1.2.0
-      pathe: 1.1.0
-      typescript: 5.0.3
-    dev: true
-
   /mkdist@1.2.0(typescript@5.0.4):
     resolution: {integrity: sha512-UTqu/bXmIk/+VKNVgufAeMyjUcNy1dn9Bl7wL1zZlCKVrpDgj/VllmZBeh3ZCC/2HWqUrt6frNFTKt9TRZbNvQ==}
     hasBin: true
@@ -9339,7 +9316,7 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /pinia@2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.3)(vue@3.2.47):
+  /pinia@2.0.33(@vue/composition-api@1.7.1)(typescript@5.0.4)(vue@3.2.47):
     resolution: {integrity: sha512-HOj1yVV2itw6rNIrR2f7+MirGNxhORjrULL8GWgRwXsGSvEqIQ+SE0MYt6cwtpegzCda3i+rVTZM+AM7CG+kRg==}
     peerDependencies:
       '@vue/composition-api': ^1.4.0
@@ -9353,7 +9330,7 @@ packages:
     dependencies:
       '@vue/composition-api': 1.7.1(vue@3.2.47)
       '@vue/devtools-api': 6.5.0
-      typescript: 5.0.3
+      typescript: 5.0.4
       vue: 3.2.47
       vue-demi: 0.13.11(@vue/composition-api@1.7.1)(vue@3.2.47)
     dev: true
@@ -11143,7 +11120,7 @@ packages:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
     dev: true
 
-  /tsup@6.7.0(typescript@5.0.3):
+  /tsup@6.7.0(typescript@5.0.4):
     resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -11173,7 +11150,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.25.0
       tree-kill: 1.2.2
-      typescript: 5.0.3
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
       - ts-node

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       '@size-limit/preset-small-lib':
         specifier: ^8.2.4
         version: 8.2.4(size-limit@8.2.4)
+      '@types/node':
+        specifier: ^18.16.2
+        version: 18.16.2
       '@types/prettier':
         specifier: ^2.7.2
         version: 2.7.2
@@ -2553,10 +2556,6 @@ packages:
 
   /@types/minimist@1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
-    dev: true
-
-  /@types/node@18.15.10:
-    resolution: {integrity: sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ==}
     dev: true
 
   /@types/node@18.16.2:
@@ -11618,27 +11617,6 @@ packages:
       extsprintf: 1.3.0
     dev: true
 
-  /vite-node@0.29.8(@types/node@18.15.10):
-    resolution: {integrity: sha512-b6OtCXfk65L6SElVM20q5G546yu10/kNrhg08afEoWlFRJXFq9/6glsvSVY+aI6YeC1tu2TtAqI2jHEQmOmsFw==}
-    engines: {node: '>=v14.16.0'}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4
-      mlly: 1.2.0
-      pathe: 1.1.0
-      picocolors: 1.0.0
-      vite: 4.2.1(@types/node@18.15.10)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@0.29.8(@types/node@18.16.2):
     resolution: {integrity: sha512-b6OtCXfk65L6SElVM20q5G546yu10/kNrhg08afEoWlFRJXFq9/6glsvSVY+aI6YeC1tu2TtAqI2jHEQmOmsFw==}
     engines: {node: '>=v14.16.0'}
@@ -11750,40 +11728,6 @@ packages:
       - supports-color
     dev: true
 
-  /vite@4.2.1(@types/node@18.15.10):
-    resolution: {integrity: sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.15.10
-      esbuild: 0.17.12
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.20.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
   /vite@4.2.1(@types/node@18.16.2):
     resolution: {integrity: sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -11851,7 +11795,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.15.10
+      '@types/node': 18.16.2
       '@vitest/expect': 0.29.8
       '@vitest/runner': 0.29.8
       '@vitest/spy': 0.29.8
@@ -11872,8 +11816,8 @@ packages:
       tinybench: 2.3.1
       tinypool: 0.4.0
       tinyspy: 1.0.2
-      vite: 4.2.1(@types/node@18.15.10)
-      vite-node: 0.29.8(@types/node@18.15.10)
+      vite: 4.2.1(@types/node@18.16.2)
+      vite-node: 0.29.8(@types/node@18.16.2)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

MInor updates are not working cause of typscript update

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
