### PR TITLE
fix(pinia-orm-1569): Wrong behaviour of `$getOriginal`

### DIFF
--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -745,7 +745,7 @@ export class Model {
       this[key] = this[key] ?? keyValue
     }
 
-    operation === 'set' && (this.$self().original[this[this.$getKeyName()]] = this.$getAttributes())
+    operation === 'set' && (this.$self().original[this[this.$getKey(this, true) as string]] = this.$getAttributes())
 
     modelConfig.withMeta && operation === 'set' && this.$fillMeta(options.action)
 
@@ -930,7 +930,7 @@ export class Model {
    * Get the original values of the model instance
    */
   $getOriginal(): Element {
-    return this.$self().original[this[this.$getKeyName()]]
+    return this.$self().original[this[this.$getKey(this, true) as string]]
   }
 
   /**

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -745,7 +745,7 @@ export class Model {
       this[key] = this[key] ?? keyValue
     }
 
-    operation === 'set' && (this.$self().original = this.$getAttributes())
+    operation === 'set' && (this.$self().original[this[this.$getKeyName()]] = this.$getAttributes())
 
     modelConfig.withMeta && operation === 'set' && this.$fillMeta(options.action)
 
@@ -930,7 +930,7 @@ export class Model {
    * Get the original values of the model instance
    */
   $getOriginal(): Element {
-    return this.$self().original
+    return this.$self().original[this[this.$getKeyName()]]
   }
 
   /**

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -259,6 +259,7 @@ export class Model {
    */
   static clearBootedModels(): void {
     this.booted = {}
+    this.original = {}
     this.schemas = {}
     this.fieldMutators = {}
     this.fieldCasts = {}

--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -745,7 +745,7 @@ export class Model {
       this[key] = this[key] ?? keyValue
     }
 
-    operation === 'set' && (this.$self().original[this[this.$getKey(this, true) as string]] = this.$getAttributes())
+    operation === 'set' && (this.$self().original[this.$getKey(this, true) as string] = this.$getAttributes())
 
     modelConfig.withMeta && operation === 'set' && this.$fillMeta(options.action)
 
@@ -930,7 +930,7 @@ export class Model {
    * Get the original values of the model instance
    */
   $getOriginal(): Element {
-    return this.$self().original[this[this.$getKey(this, true) as string]]
+    return this.$self().original[this.$getKey(this, true) as string]
   }
 
   /**

--- a/packages/pinia-orm/src/store/Config.ts
+++ b/packages/pinia-orm/src/store/Config.ts
@@ -4,7 +4,7 @@ import type { FilledInstallOptions } from './Store'
 export const CONFIG_DEFAULTS = {
   model: {
     withMeta: false,
-    hidden: ['_meta'],
+    hidden: ['_meta', 'original'],
     visible: ['*'],
   },
   cache: {

--- a/packages/pinia-orm/tests/unit/model/Model.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { computed } from 'vue-demi'
 
-import { Model } from '../../../src'
+import { Model, useRepo } from '../../../src'
 import { Attr } from '../../../src/decorators'
 
 describe('unit/model/Model', () => {
@@ -39,5 +40,28 @@ describe('unit/model/Model', () => {
     expect(user.$isDirty()).toBeFalsy()
     expect(user.lastName).toBe('John Doe')
     expect(() => user.$isDirty('name')).toThrowError()
+  })
+
+  it('it displays states correctly with multiple same models', () => {
+    const userRepo = useRepo(User)
+    userRepo.save([
+      {
+        id: 1,
+        lastName: 'JohnK',
+      },
+      {
+        id: 2,
+        lastName: 'JaneD',
+      },
+      {
+        id: 3,
+        lastName: 'TomH',
+      },
+    ])
+
+    const users = computed(() => userRepo.all())
+    const usersOriginal = computed(() => users.value.map(u => u.$getOriginal()))
+
+    expect(users.value.map(user => user.$toJson())).toEqual(usersOriginal.value)
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #1569 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The orginal data state was always overwritten by the last model called. That way `$getOrginal` never worked correctly.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
