### PR TITLE
docs: add Compositekey lookup

### DIFF
--- a/docs/content/1.guide/3.relationships/3.one-to-many.md
+++ b/docs/content/1.guide/3.relationships/3.one-to-many.md
@@ -198,7 +198,7 @@ class Post extends Model {
 }
 ```
 
-Though posts do not contain a country_id column, the `hasManyThrough` relation provides access to a country's posts. To perform this query, Vuex ORM inspects the `country_id` on the intermediate User model. After finding the matching user IDs, they are used to query the Post model.
+Though posts do not contain a country_id column, the `hasManyThrough` relation provides access to a country's posts. To perform this query, Pinia ORM inspects the `country_id` on the intermediate User model. After finding the matching user IDs, they are used to query the Post model.
 
 The first argument passed to the `hasManyThrough` method is the final model we wish to access, while the second argument is the intermediate model. The third argument is the name of the foreign key on the intermediate model. The fourth argument is the name of the foreign key on the final model.
 

--- a/docs/content/1.guide/4.repository/2.retrieving-data.md
+++ b/docs/content/1.guide/4.repository/2.retrieving-data.md
@@ -76,6 +76,19 @@ const user = useRepo(User).find(1)
 const user = useRepo(User).where('active', true).first()
 ```
 
+### Retrieving models with composite keys
+
+You can query a record that has composite primary keys by passing the key as a string like so:
+
+```js
+// Retrieve a model by its primary key.
+const user = useRepo(User).find('[1,2]')
+
+// Retrieve the first model matching the query constraints.
+const user = useRepo(User).whereId('[1,2]').first()
+```
+
+
 ## Where Clauses
 
 You may use the `where` method to add `where` clauses to the query. The most basic call to `where` requires 2 arguments. The first argument is the name of the field. The second argument is the value to evaluate against the field.

--- a/docs/content/1.guide/4.repository/5.deleting-data.md
+++ b/docs/content/1.guide/4.repository/5.deleting-data.md
@@ -66,3 +66,15 @@ You can also run a delete statement on a set of records. In this example, we wil
 ```js
 useRepo(User).where('active', false).delete()
 ```
+
+### Deleting models with composite keys
+
+You can delete a record that has composite primary keys by passing the key as a string like so:
+
+```js
+// Delete using destroy
+useRepo(User).destroy('[1,2]')
+
+// Delete by query 
+useRepo(User).whereId('["hi","there"]').delete()
+```


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/CodeDredd/pinia-orm/pull/1206

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Now that we can query records with composite primary in 1.7 it should probably be in the docs. This pr adds it to the retrieving and deleting models section.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
