### PR TITLE
docs: Fixed insert incorrect example in single table inheritance docs

### DIFF
--- a/docs/content/1.guide/2.model/7.single-table-inheritance.md
+++ b/docs/content/1.guide/2.model/7.single-table-inheritance.md
@@ -52,9 +52,7 @@ For typescript look at this [discussion](https://github.com/CodeDredd/pinia-orm/
 Once you defined a sub-class, you can `insert` / `create` / `update` / `get` / `delete` entities using the Model static methods. For instance, to create or insert data:
 
 ```js
-useRepo(Adult).insert({ 
-  data: { id: 1, name: 'John Doe', job: 'Software Engineer' }
-})
+useRepo(Adult).insert({id: 1, name: 'John Doe', job: 'Software Engineer' })
 ```
 
 And to fetch data: 
@@ -132,12 +130,11 @@ Now, you can create mixed types of records at once.
 
 ```js
 // Creating mixed data.
-useRepo(Person).insert({ 
-  data: [
+useRepo(Person).insert([
     { type:'PERSON', id: 1, name: 'John Doe' },
     { type:'ADULT', id: 2, name: 'Jane Doe', job: 'Software Engineer' }
   ]
-})
+)
 
 const people = useRepo(Person).all()
 
@@ -193,12 +190,11 @@ class Adult extends Person {
 And now you may use a custom `type` field when inserting data.
 
 ```js
-useRepo(Person).insert({ 
-  data: [
+useRepo(Person).insert([
     { person_type: 'PERSON', id: 1, name: 'John Doe' },
     { person_type: 'ADULT', id: 2, name: 'Jane Doe', job: 'Software Engineer' }
   ]
-})
+)
 
 const people = useRepo(Person).all()
 
@@ -253,12 +249,10 @@ Then you can fetch the key with its results.
 
 ```js
 // Creating mixed data
-useRepo(Person).insert({ 
-  data: [
+useRepo(Person).insert([
     { type:'PERSON', id: 1, name: 'John Doe' },
     { type:'ADULT', id: 2, name: 'Jane Doe', job: 'Software Engineer' }
-  ]
-})
+  ])
 
 const people = useRepo(Person).all()
 
@@ -321,21 +315,15 @@ class Address extends Model {
 And let's see what would happen in this case.
 
 ```js
-useRepo(Address).insert({
-  data: [
+useRepo(Address).insert([
     { id: 1, city: 'TOKYO' },
     { id: 2, city: 'PARIS' },
     { id: 3, city: 'BERLIN' }
-  ]
-})
+  ])
 
-useRepo(Person).insert({
-  data: { id: 1, home_address_id: 1, name: 'John Doe' }
-})
+useRepo(Person).insert({ id: 1, home_address_id: 1, name: 'John Doe' })
 
-useRepo(Adult).insert({
-  data: { id: 2, home_address_id: 2, work_address_id: 3, name: 'Jane Doe', job: 'Software Engineer' }
-})
+useRepo(Adult).insert({ id: 2, home_address_id: 2, work_address_id: 3, name: 'Jane Doe', job: 'Software Engineer' })
 
 const people = useRepo(Person).query().with(['home_address', 'work_address']).get()
 


### PR DESCRIPTION
The .insert had the `{data:...}` field from vuex-orm in the examples. This pr removes that.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The .insert had the `{data:...}` field from vuex-orm in the examples. This pr removes the data field.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
