### PR TITLE
feat(pinia-orm): Composite primary key can now be used with `destroy` and `onDelete`

### DIFF
--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -817,7 +817,7 @@ export class Model {
 
     if (this.$hasCompositeKey()) {
       const compositeKey = this.$getCompositeKey(record)
-      return concatCompositeKey ? compositeKey?.join('') ?? null : compositeKey
+      return concatCompositeKey ? '[' + compositeKey?.join(',') + ']' : compositeKey
     }
 
     const id = record[this.$getKeyName() as string]

--- a/packages/pinia-orm/src/query/Query.ts
+++ b/packages/pinia-orm/src/query/Query.ts
@@ -1,7 +1,8 @@
 import type { Pinia } from 'pinia'
 import { acceptHMRUpdate } from 'pinia'
 import {
-  assert, compareWithOperator, generateKey,
+  compareWithOperator,
+  generateKey,
   groupBy,
   isArray,
   isEmpty,
@@ -859,11 +860,6 @@ export class Query<M extends Model = Model> {
   destroy(ids: (string | number)[]): Collection<M>
   destroy(id: string | number): Item<M>
   destroy (ids: any): any {
-    assert(!this.model.$hasCompositeKey(), [
-      'You can\'t use the `destroy` method on a model with a composite key.',
-      'Please use `delete` method instead.'
-    ])
-
     return isArray(ids) ? this.destroyMany(ids) : this.destroyOne(ids)
   }
 
@@ -928,7 +924,7 @@ export class Query<M extends Model = Model> {
       if (fields[name] instanceof Relation && relation.onDeleteMode && model[name]) {
         const models = isArray(model[name]) ? model[name] : [model[name]]
         const relationIds = models.map((relation: M) => {
-          return relation[relation.$getLocalKey()]
+          return relation.$getKey(undefined, true)
         })
         const record: Record<string, any> = {}
 

--- a/packages/pinia-orm/tests/feature/repository/delete_with_relations.spec.ts
+++ b/packages/pinia-orm/tests/feature/repository/delete_with_relations.spec.ts
@@ -29,7 +29,10 @@ describe('feature/repository/delete_with_relations', () => {
     class Comment extends Model {
       static entity = 'comments'
 
+      static primaryKey = ['id', 'comment_id']
+
       @Num(0) declare id: number
+      @Num(0) declare comment_id: number
       @Num(0) declare postId: number
       @Str('') declare title: string
     }
@@ -111,8 +114,8 @@ describe('feature/repository/delete_with_relations', () => {
           id: 1,
           title: 'Title 01',
           comments: [
-            { id: 3, title: 'Title 03' },
-            { id: 4, title: 'Title 04' }
+            { id: 3, comment_id: 3, title: 'Title 03' },
+            { id: 4, comment_id: 3, title: 'Title 04' }
           ],
           extraComments: [
             { id: 3, title: 'Title 03' },
@@ -131,8 +134,8 @@ describe('feature/repository/delete_with_relations', () => {
           id: 3,
           title: 'Title 03',
           comments: [
-            { id: 1, title: 'Title 01' },
-            { id: 2, title: 'Title 02' }
+            { id: 1, comment_id: 3, title: 'Title 01' },
+            { id: 2, comment_id: 3, title: 'Title 02' }
           ],
           extraComments: [
             { id: 1, title: 'Title 01' },
@@ -169,8 +172,8 @@ describe('feature/repository/delete_with_relations', () => {
         2: { id: 2, userId: 1, title: 'Title 02' }
       },
       comments: {
-        3: { id: 3, postId: 1, title: 'Title 03' },
-        4: { id: 4, postId: 1, title: 'Title 04' }
+        '[3,3]': { id: 3, comment_id: 3, postId: 1, title: 'Title 03' },
+        '[4,3]': { id: 4, comment_id: 3, postId: 1, title: 'Title 04' }
       },
       extraComments: {
         3: { id: 3, postId: 1, title: 'Title 03' },
@@ -187,6 +190,7 @@ describe('feature/repository/delete_with_relations', () => {
   })
 
   it('works with morph relations', () => {
+    Model.clearRegistries()
     class Comment extends Model {
       static entity = 'comments'
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

resolves #1620

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adding support for composite key `destroy` because lookup already works with it. Also adapted `onDelete` to work with it.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
