### PR TITLE
fix(pinia-orm): proper exports for collection and uid helpers

### DIFF
--- a/docs/content/1.guide/1.getting-started/1.quick-start.md
+++ b/docs/content/1.guide/1.getting-started/1.quick-start.md
@@ -93,7 +93,7 @@ description: ''
   // User Model
 
   import { Model } from 'pinia-orm'
-  import { Str, Uid } from 'pinia-orm/dist/decorators'
+  import { Str, Uid } from 'pinia-orm/decorators'
   
   export default class User extends Model {
     // entity is a required property for all models.
@@ -144,7 +144,7 @@ description: ''
   // Post Model
 
   import { Model } from 'pinia-orm'
-  import { Attr, BelongsTo, Bool, Str, Uid } from 'pinia-orm/dist/decorators'
+  import { Attr, BelongsTo, Bool, Str, Uid } from 'pinia-orm/decorators'
   import User from './User'
   
   export default class Post extends Model {

--- a/docs/content/1.guide/1.getting-started/2.usage.md
+++ b/docs/content/1.guide/1.getting-started/2.usage.md
@@ -34,4 +34,4 @@ const userRepo = useRepo(User, this.$pinia)
 Look into the [Api Guide](../../api/composables/helpers/use-collect) for usages of `useCollect` and more
 
 The nice thing of these composables is that they work also with existing `vuex-orm` and `vuex-orm-net`. So if you like them
-you can just import these helpers e.g. by `import { useCollect }` from `pinia-orm/dist/helpers`
+you can just import these helpers e.g. by `import { useCollect }` from `pinia-orm/helpers`

--- a/docs/content/1.guide/1.getting-started/4.typescript.md
+++ b/docs/content/1.guide/1.getting-started/4.typescript.md
@@ -22,8 +22,8 @@ This is pretty new if you are a vuex-orm user. If you are a vuex-orm-next user t
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, Cast, Uid } from 'pinia-orm/dist/decorators'
-import { ArrayCast } from 'pinia-orm/dist/casts'
+import { Attr, Cast, Uid } from 'pinia-orm/decorators'
+import { ArrayCast } from 'pinia-orm/casts'
 
 class User extends Model {
   static entity = 'users'
@@ -41,8 +41,8 @@ For more information about using `declare` read this [ticket](https://github.com
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, Cast, Uid } from 'pinia-orm/dist/decorators'
-import { ArrayCast } from 'pinia-orm/dist/casts'
+import { Attr, Cast, Uid } from 'pinia-orm/decorators'
+import { ArrayCast } from 'pinia-orm/casts'
 
 class User extends Model {
   static entity = 'users'
@@ -70,7 +70,7 @@ Make sure to disable `useDefineForClassFields` in `tsconfig.json` when using `vi
 
 ````ts
 import { Model } from 'pinia-orm'
-import { ArrayCast } from 'pinia-orm/dist/casts'
+import { ArrayCast } from 'pinia-orm/casts'
 
 class User extends Model {
   static entity = 'users'

--- a/docs/content/1.guide/2.model/1.getting-started.md
+++ b/docs/content/1.guide/2.model/1.getting-started.md
@@ -214,9 +214,9 @@ Please make sure that you have `nanoid` installed:
 For more details look at [nanoid](https://github.com/ai/nanoid). Standard methods
 
 ```js
-import { UidCast } from 'pinia-orm/dist/nanoid'
-// import { UidCast } from 'pinia-orm/dist/nanoid/non-secure'
-// import { UidCast } from 'pinia-orm/dist/nanoid/async'
+import { UidCast } from 'pinia-orm/nanoid'
+// import { UidCast } from 'pinia-orm/nanoid/non-secure'
+// import { UidCast } from 'pinia-orm/nanoid/async'
 
 class User extends Model {
   static entity = 'users'
@@ -239,9 +239,9 @@ class User extends Model {
 with decorator:
 
 ```ts
-import { Uid } from 'pinia-orm/dist/nanoid'
-// import { Uid } from 'pinia-orm/dist/nanoid/non-secure'
-// import { Uid } from 'pinia-orm/dist/nanoid/async'
+import { Uid } from 'pinia-orm/nanoid'
+// import { Uid } from 'pinia-orm/nanoid/non-secure'
+// import { Uid } from 'pinia-orm/nanoid/async'
 
 class User extends Model {
   static entity = 'users'
@@ -269,8 +269,8 @@ Please make sure that you have `uuid` installed:
 For more details look at [uuid](https://github.com/uuidjs/uuid). Standard methods
 
 ```js
-import { UidCast } from 'pinia-orm/dist/uuid/v1'
-// import { UidCast } from 'pinia-orm/dist/uuid/v4'
+import { UidCast } from 'pinia-orm/uuid/v1'
+// import { UidCast } from 'pinia-orm/uuid/v4'
 
 class User extends Model {
   static entity = 'users'
@@ -293,8 +293,8 @@ class User extends Model {
 with decorator:
 
 ```ts
-import { Uid } from 'pinia-orm/dist/uuid/v1'
-// import { Uid } from 'pinia-orm/dist/uuid/v4'
+import { Uid } from 'pinia-orm/uuid/v1'
+// import { Uid } from 'pinia-orm/uuid/v4'
 
 class User extends Model {
   static entity = 'users'

--- a/docs/content/1.guide/2.model/2.accessors.md
+++ b/docs/content/1.guide/2.model/2.accessors.md
@@ -83,7 +83,7 @@ the value before it is saved in the store.
 
 ````ts
 import { Model, useRepo } from 'pinia-orm'
-import { Attr } from 'pinia-orm/dist/decorators'
+import { Attr } from 'pinia-orm/decorators'
 import { getActivePinia } from 'pinia';
 
 class User extends Model {

--- a/docs/content/1.guide/2.model/4.decorators.md
+++ b/docs/content/1.guide/2.model/4.decorators.md
@@ -5,7 +5,7 @@ description: ''
 # Decorators
 
 ::alert{type=warning}
-Since `v1.0.0-rc-6` the decorators moved to `pinia-orm/dist/decorators` from `pinia-orm`
+Since `v1.0.0-rc-6` the decorators moved to `pinia-orm/decorators` from `pinia-orm`
 ::
 
 Pinia ORM provides property decorators to Typescript users for better type support when defining the schema for an entity. Simply put, decorators replace the need to define the `fields` method.
@@ -14,7 +14,7 @@ The following example defines a User model using decorators on properties that f
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Attr, Str, HasMany } from 'pinia-orm/dist/decorators'
+import { Attr, Str, HasMany } from 'pinia-orm/decorators'
 import Post from '@/models/Post'
 
 class User extends Model {
@@ -57,7 +57,7 @@ Marks a property on the model as a [generic attribute](getting-started.md#generi
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Attr } from 'pinia-orm/dist/decorators'
+import { Attr } from 'pinia-orm/decorators'
 
 export class User extends Model {
   static entity = 'users'
@@ -74,7 +74,7 @@ Marks a property on the model as a [string attribute](./getting-started#string-t
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Attr, Str } from 'pinia-orm/dist/decorators'
+import { Attr, Str } from 'pinia-orm/decorators'
 
 export class User extends Model {
   static entity = 'users'
@@ -90,7 +90,7 @@ Marks a property on the model as a [number attribute](./getting-started#string-t
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Num } from 'pinia-orm/dist/decorators'
+import { Num } from 'pinia-orm/decorators'
 
 export class User extends Model {
   static entity = 'users'
@@ -107,7 +107,7 @@ Marks a property on the model as a [boolean attribute](./getting-started#boolean
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Bool } from 'pinia-orm/dist/decorators'
+import { Bool } from 'pinia-orm/decorators'
 
 export class User extends Model {
   static entity = 'users'
@@ -123,7 +123,7 @@ Marks a property on the model as a [Uid attribute](./getting-started#uid-type) t
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Uid } from 'pinia-orm/dist/decorators'
+import { Uid } from 'pinia-orm/decorators'
 
 class User extends Model {
   static entity = 'users'
@@ -138,7 +138,7 @@ Adds a [mutator](/model/accessors#defining-mutators) to a property on the model.
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, Mutate } from 'pinia-orm/dist/decorators'
+import { Attr, Mutate } from 'pinia-orm/decorators'
 
 class User extends Model {
   static entity = 'users'
@@ -155,7 +155,7 @@ Adds a cast to a property on the model. For example:
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, Cast } from 'pinia-orm/dist/decorators'
+import { Attr, Cast } from 'pinia-orm/decorators'
 import { StringCast } from 'pinia-orm/casts'
 
 class User extends Model {
@@ -177,7 +177,7 @@ Marks a property on the model as a [hasOne attribute](../relationships/getting-s
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Attr, HasOne } from 'pinia-orm/dist/decorators'
+import { Attr, HasOne } from 'pinia-orm/decorators'
 import Phone from '@/models/Phone'
 
 class User extends Model {
@@ -193,7 +193,7 @@ Marks a property on the model as a [belongsTo attribute](../relationships/gettin
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Attr, BelongsTo } from 'pinia-orm/dist/decorators'
+import { Attr, BelongsTo } from 'pinia-orm/decorators'
 import User from '@/models/User'
 
 class Post extends Model {
@@ -210,7 +210,7 @@ Marks a property on the model as a [hasMany attribute](../relationships/getting-
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Attr, HasMany } from 'pinia-orm/dist/decorators'
+import { Attr, HasMany } from 'pinia-orm/decorators'
 import Post from '@/models/Post'
 
 class User extends Model {
@@ -226,7 +226,7 @@ Marks a property on the model as a [hasManyBy attribute](../relationships/one-to
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Attr, HasManyBy } from 'pinia-orm/dist/decorators'
+import { Attr, HasManyBy } from 'pinia-orm/decorators'
 import Node from '@/models/Node'
 
 class Cluster extends Model {
@@ -243,7 +243,7 @@ Marks a property on the model as a [belongsToMany attribute](../relationships/ma
 
 ```ts
 import { Model } from 'pinia-orm'
-import { BelongsToMany } from 'pinia-orm/dist/decorators'
+import { BelongsToMany } from 'pinia-orm/decorators'
 import Role from '@/models/Role'
 
 class User extends Model {
@@ -259,7 +259,7 @@ Marks a property on the model as a [morphOne attribute](../relationships/polymor
 
 ```ts
 import { Model } from 'pinia-orm'
-import { MorphOne } from 'pinia-orm/dist/decorators'
+import { MorphOne } from 'pinia-orm/decorators'
 import Image from '@/models/Image'
 
 class User extends Model {
@@ -275,7 +275,7 @@ Marks a property on the model as a [morphTo attribute](../relationships/polymorp
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Attr, MorphTo } from 'pinia-orm/dist/decorators'
+import { Attr, MorphTo } from 'pinia-orm/decorators'
 import User from '@/models/User'
 import Post from '@/models/Post'
 
@@ -294,7 +294,7 @@ Marks a property on the model as a [morphMany attribute](../relationships/polymo
 
 ```ts
 import { Model } from 'pinia-orm'
-import { MorphMany } from 'pinia-orm/dist/decorators'
+import { MorphMany } from 'pinia-orm/decorators'
 import Comment from '@/models/Comment'
 class Video extends Model {
   static entity = 'videos'
@@ -309,7 +309,7 @@ Marks a property on the model as a [morphToMany attribute](../relationships/poly
 
 ```ts
 import { Model } from 'pinia-orm'
-import { MorphToMany } from 'pinia-orm/dist/decorators'
+import { MorphToMany } from 'pinia-orm/decorators'
 import Comment from '@/models/Comment'
 import Commentable from '@/models/Commantable'
 class Video extends Model {
@@ -327,7 +327,7 @@ Marks a property on the model as a [hasMany attribute](../relationships/getting-
 
 ```ts
 import { Model } from 'pinia-orm'
-import { Attr, HasMany, OnDelete } from 'pinia-orm/dist/decorators'
+import { Attr, HasMany, OnDelete } from 'pinia-orm/decorators'
 import Post from '@/models/Post'
 
 class User extends Model {

--- a/docs/content/1.guide/2.model/6.pinia-options.md
+++ b/docs/content/1.guide/2.model/6.pinia-options.md
@@ -14,7 +14,7 @@ And therefore you need to be able to pass options to your store definition.
 
 ```ts[user.ts]
 import { Model } from 'pinia-orm'
-import { Attr, Str } from 'pinia-orm/dist/decorators'
+import { Attr, Str } from 'pinia-orm/decorators'
 import Post from '@/models/Post'
 
 class User extends Model {
@@ -35,7 +35,7 @@ Through this options you can also overwrite the default pinia actions and add ev
 
 ```ts[user.ts]
 import { DataStore, Model, useStoreActions, Elements } from 'pinia-orm'
-import { Attr, Str } from 'pinia-orm/dist/decorators'
+import { Attr, Str } from 'pinia-orm/decorators'
 import Post from '@/models/Post'
 
 class User extends Model {

--- a/docs/content/2.api/1.composables/2.helpers/use-collect.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-collect.md
@@ -11,7 +11,7 @@ For Details what each function can do, look at the separate composable for it e.
 
 ````ts
 import { useRepo } from 'pinia-orm'
-import { useCollect } from 'pinia-orm/dist/helpers'
+import { useCollect } from 'pinia-orm/helpers'
 import User from './models/User'
 
 const users = useRepo(User).all()

--- a/docs/content/2.api/1.composables/2.helpers/use-group-by.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-group-by.md
@@ -9,7 +9,7 @@ description: 'The useGroupBy method groups the collections items by a given key.
 
 ````ts
 import { useRepo } from 'pinia-orm'
-import { useGroupBy } from 'pinia-orm/dist/helpers'
+import { useGroupBy } from 'pinia-orm/helpers'
 import User from './models/User'
 
 const users = useRepo(User).all()

--- a/docs/content/2.api/1.composables/2.helpers/use-keys.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-keys.md
@@ -9,7 +9,7 @@ description: 'The keys method returns all of the collections primary keys'
 
 ````ts
 import { useRepo } from 'pinia-orm'
-import { useKeys } from 'pinia-orm/dist/helpers'
+import { useKeys } from 'pinia-orm/helpers'
 import User from './models/User'
 
 const users = useRepo(User).all()

--- a/docs/content/2.api/1.composables/2.helpers/use-max.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-max.md
@@ -9,7 +9,7 @@ description: 'Get the max value of the specified filed.'
 
 ````ts
 import { useRepo } from 'pinia-orm'
-import { useMax } from 'pinia-orm/dist/helpers'
+import { useMax } from 'pinia-orm/helpers'
 import User from './models/User'
 
 const users = useRepo(User).all()

--- a/docs/content/2.api/1.composables/2.helpers/use-min.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-min.md
@@ -9,7 +9,7 @@ description: 'Get the min value of the specified filed.'
 
 ````ts
 import { useRepo } from 'pinia-orm'
-import { useMin } from 'pinia-orm/dist/helpers'
+import { useMin } from 'pinia-orm/helpers'
 import User from './models/User'
 
 const users = useRepo(User).all()

--- a/docs/content/2.api/1.composables/2.helpers/use-pluck.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-pluck.md
@@ -9,7 +9,7 @@ description: 'The pluck method retrieves all of the values for a given key.'
 
 ````ts
 import { useRepo } from 'pinia-orm'
-import { usePluck } from 'pinia-orm/dist/helpers'
+import { usePluck } from 'pinia-orm/helpers'
 import User from './models/User'
 
 const users = useRepo(User).all()

--- a/docs/content/2.api/1.composables/2.helpers/use-sort-by.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-sort-by.md
@@ -9,7 +9,7 @@ description: 'Sorts the collection by a given key'
 
 ````ts
 import { useRepo } from 'pinia-orm'
-import { useSortBy } from 'pinia-orm/dist/helpers'
+import { useSortBy } from 'pinia-orm/helpers'
 import User from './models/User'
 
 const users = useRepo(User).all()

--- a/docs/content/2.api/1.composables/2.helpers/use-sum.md
+++ b/docs/content/2.api/1.composables/2.helpers/use-sum.md
@@ -9,7 +9,7 @@ description: 'Get the sum value of the specified filed.'
 
 ````ts
 import { useRepo } from 'pinia-orm'
-import { useSum } from 'pinia-orm/dist/helpers'
+import { useSum } from 'pinia-orm/helpers'
 import User from './models/User'
 
 const users = useRepo(User).all()

--- a/docs/content/2.api/2.model/1.options/1.fields-attributes/attr.md
+++ b/docs/content/2.api/2.model/1.options/1.fields-attributes/attr.md
@@ -27,7 +27,7 @@ class User extends Model {
 
 ````ts[User.ts]
 import { Model } from 'pinia-orm'
-import { Attr } from 'pinia-orm/dist/decorators'
+import { Attr } from 'pinia-orm/decorators'
 
 class User extends Model {
   static entity = 'users'

--- a/docs/content/2.api/2.model/1.options/1.fields-attributes/boolean.md
+++ b/docs/content/2.api/2.model/1.options/1.fields-attributes/boolean.md
@@ -27,7 +27,7 @@ class User extends Model {
 
 ````ts[User.ts]
 import { Model } from 'pinia-orm'
-import { Bool, Num } from 'pinia-orm/dist/decorators'
+import { Bool, Num } from 'pinia-orm/decorators'
 
 class User extends Model {
   static entity = 'users'

--- a/docs/content/2.api/2.model/1.options/1.fields-attributes/number.md
+++ b/docs/content/2.api/2.model/1.options/1.fields-attributes/number.md
@@ -26,7 +26,7 @@ class User extends Model {
 
 ````ts[User.ts]
 import { Model } from 'pinia-orm'
-import { Num } from 'pinia-orm/dist/decorators'
+import { Num } from 'pinia-orm/decorators'
 
 class User extends Model {
   static entity = 'users'

--- a/docs/content/2.api/2.model/1.options/1.fields-attributes/string.md
+++ b/docs/content/2.api/2.model/1.options/1.fields-attributes/string.md
@@ -27,7 +27,7 @@ class User extends Model {
 
 ````ts[User.ts]
 import { Model } from 'pinia-orm'
-import { Num, Str } from 'pinia-orm/dist/decorators'
+import { Num, Str } from 'pinia-orm/decorators'
 
 class User extends Model {
   static entity = 'users'

--- a/docs/content/2.api/2.model/1.options/1.fields-attributes/uid.md
+++ b/docs/content/2.api/2.model/1.options/1.fields-attributes/uid.md
@@ -25,7 +25,7 @@ class User extends Model {
 
 ````ts[User.ts]
 import { Model } from 'pinia-orm'
-import { Uid } from 'pinia-orm/dist/decorators'
+import { Uid } from 'pinia-orm/decorators'
 
 class User extends Model {
   static entity = 'users'

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/belongs-to-many.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/belongs-to-many.md
@@ -28,7 +28,7 @@ class User extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, BelongsToMany, Str } from 'pinia-orm/dist/decorators'
+import { Attr, BelongsToMany, Str } from 'pinia-orm/decorators'
 import Role from './Role'
 import RoleUser from './RoleUser'
 

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/belongs-to.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/belongs-to.md
@@ -29,7 +29,7 @@ class Phone extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, BelongsTo, Str } from 'pinia-orm/dist/decorators'
+import { Attr, BelongsTo, Str } from 'pinia-orm/decorators'
 import User from './User'
 
 class User extends Model {

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/has-many-by.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/has-many-by.md
@@ -29,7 +29,7 @@ class Post extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, HasManyBy, Str } from 'pinia-orm/dist/decorators'
+import { Attr, HasManyBy, Str } from 'pinia-orm/decorators'
 import Comment from './Comment'
 
 class Post extends Model {

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/has-many-through.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/has-many-through.md
@@ -49,7 +49,7 @@ class Post extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, HasManyThrough, Str } from 'pinia-orm/dist/decorators'
+import { Attr, HasManyThrough, Str } from 'pinia-orm/decorators'
 
 class Country extends Model {
   static entity = 'countries'

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/has-many.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/has-many.md
@@ -28,7 +28,7 @@ class Post extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, HasMany, Str } from 'pinia-orm/dist/decorators'
+import { Attr, HasMany, Str } from 'pinia-orm/decorators'
 import Comment from './Comment'
 
 class Post extends Model {

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/has-one.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/has-one.md
@@ -28,7 +28,7 @@ class User extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, HasOne, Str } from 'pinia-orm/dist/decorators'
+import { Attr, HasOne, Str } from 'pinia-orm/decorators'
 import Phone from './Phone'
 
 class User extends Model {

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/morph-many.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/morph-many.md
@@ -28,7 +28,7 @@ class User extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, MorphMany, Str } from 'pinia-orm/dist/decorators'
+import { Attr, MorphMany, Str } from 'pinia-orm/decorators'
 import Image from './Image'
 
 class User extends Model {

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/morph-one.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/morph-one.md
@@ -28,7 +28,7 @@ class User extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, MorphOne, Str } from 'pinia-orm/dist/decorators'
+import { Attr, MorphOne, Str } from 'pinia-orm/decorators'
 import Image from './Image'
 
 class User extends Model {

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/morph-to-many.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/morph-to-many.md
@@ -29,7 +29,7 @@ class User extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, MorphToMany, Str } from 'pinia-orm/dist/decorators'
+import { Attr, MorphToMany, Str } from 'pinia-orm/decorators'
 import Image from './Image'
 import Imageable from './Image'
 

--- a/docs/content/2.api/2.model/1.options/2.fields-relations/morph-to.md
+++ b/docs/content/2.api/2.model/1.options/2.fields-relations/morph-to.md
@@ -35,7 +35,7 @@ class Image extends Model {
 
 ````ts
 import { Model } from 'pinia-orm'
-import { Attr, MorphTo, Str } from 'pinia-orm/dist/decorators'
+import { Attr, MorphTo, Str } from 'pinia-orm/decorators'
 import User from './Image'
 import Post from './Post'
 

--- a/docs/content/2.api/2.model/1.options/3.casts.md
+++ b/docs/content/2.api/2.model/1.options/3.casts.md
@@ -128,7 +128,7 @@ class User extends Model {
 
 ````ts[User.ts]
 import { Model } from 'pinia-orm'
-import { Attr, Cast } from 'pinia-orm/dist/decorators'
+import { Attr, Cast } from 'pinia-orm/decorators'
 import { ArrayCast } from 'pinia-orm/casts'
 
 class User extends Model {

--- a/docs/content/2.api/2.model/1.options/3.hidden.md
+++ b/docs/content/2.api/2.model/1.options/3.hidden.md
@@ -33,7 +33,7 @@ class User extends Model {
 
 ````ts[User.ts]
 import { Model } from 'pinia-orm'
-import { Attr, Hidden, Uid } from 'pinia-orm/dist/decorators'
+import { Attr, Hidden, Uid } from 'pinia-orm/decorators'
 
 class User extends Model {
   static entity = 'users'

--- a/docs/content/2.api/2.model/1.options/3.mutators.md
+++ b/docs/content/2.api/2.model/1.options/3.mutators.md
@@ -37,7 +37,7 @@ class User extends Model {
 
 ````ts[User.ts]
 import { Model } from 'pinia-orm'
-import { Attr, Mutate } from 'pinia-orm/dist/decorators'
+import { Attr, Mutate } from 'pinia-orm/decorators'
 
 class User extends Model {
   static entity = 'users'

--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -26,16 +26,10 @@
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     },
-    "./*": "./*",
-    "./decorators": {
-      "types": "./dist/decorators.d.ts",
-      "require": "./dist/decorators.cjs",
-      "import": "./dist/decorators.mjs"
-    },
-    "./casts": {
-      "types": "./dist/casts.d.ts",
-      "require": "./dist/casts.cjs",
-      "import": "./dist/casts.mjs"
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "require": "./dist/*.cjs",
+      "import": "./dist/*.mjs"
     }
   },
   "files": [


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#1680

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #1680.
All imports are now possible without specifying `dist` folder.
For those who used `dist` and it worked for them - it should still work too (I _think_).
Docs updated accordingly (all `dist` references removed).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
