### PR TITLE
fix(pinia-orm): `.find` returning type `any` when using `useRepo`

### DIFF
--- a/packages/pinia-orm/src/types/repository.ts
+++ b/packages/pinia-orm/src/types/repository.ts
@@ -31,6 +31,5 @@ declare module '../repository/Repository' {
      */
     find (id: string | number): Item<M>
     find (ids: (string | number)[]): Collection<M>
-    find (ids: any): Item<any>
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1863

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Pinia ORM!
----------------------------------------------------------------------->
