### PR TITLE
fix(pinia-orm): Change plugin registration to be still compatible with pinia types

### DIFF
--- a/docs/content/3.plugins/1.introduction.md
+++ b/docs/content/3.plugins/1.introduction.md
@@ -25,8 +25,11 @@ import { piniaOrmPlugin } from './plugins'
 
 const app = createApp({})
 const pinia = createPinia()
-const piniaOrm = createORM()
-piniaOrm().use(piniaOrmPlugin)
+const piniaOrm = createORM({
+  plugins: [
+    piniaOrmPlugin()
+  ],
+})
 pinia.use(piniaOrm)
 app.use(pinia)
 setActivePinia(pinia)

--- a/docs/content/3.plugins/2.axios/1.guide/1.setup.md
+++ b/docs/content/3.plugins/2.axios/1.guide/1.setup.md
@@ -29,10 +29,13 @@ or you use `pinaOrmPluginAxios`. It depends if you want to pass options on initi
   import axios from 'axios'
 
   const pinia = createPinia()
-  const piniaOrm = createORM()
-  piniaOrm().use(createPiniaOrmAxios({
-    axios
-  }))
+  const piniaOrm = createORM({
+    plugins: [
+      createPiniaOrmAxios({
+        axios,
+      }),
+    ],
+  })
   pinia.use(piniaOrm)
   ```
   ```js{}[Vue2]
@@ -43,10 +46,13 @@ or you use `pinaOrmPluginAxios`. It depends if you want to pass options on initi
 
   Vue.use(PiniaVuePlugin)
   const pinia = createPinia()
-  const piniaOrm = createORM()
-  piniaOrm().use(createPiniaOrmAxios({
-    axios
-  }))
+  const piniaOrm = createORM({
+    plugins: [
+      createPiniaOrmAxios({
+        axios,
+      }),
+    ],
+  })
   pinia.use(piniaOrm)
   ```
 ::

--- a/docs/content/3.plugins/2.axios/1.guide/2.configuration.md
+++ b/docs/content/3.plugins/2.axios/1.guide/2.configuration.md
@@ -19,12 +19,15 @@ import axios from 'axios'
 import { createORM } from 'pinia-orm'
 import { createPiniaOrmPluginAxios } from '@pinia-orm/axios'
 
-const piniaOrm = createORM()
-piniaOrm().use(createPiniaOrmPluginAxios({
-  axios,
-  headers: { 'X-Requested-With': 'XMLHttpRequest' },
-  baseURL: 'https://example.com/api/'
-}))
+const piniaOrm = createORM({
+  plugins: [
+    createPiniaOrmAxios({
+      axios,
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      baseURL: 'https://example.com/api/',
+    }),
+  ],
+})
 ```
 
 ### Model Configuration

--- a/packages/axios/test/setup.ts
+++ b/packages/axios/test/setup.ts
@@ -16,10 +16,13 @@ beforeAll(() => {
 beforeEach(() => {
   const app = createApp({})
   const pinia = createPinia()
-  const piniaOrm = createORM()
-  piniaOrm().use(createPiniaOrmAxios({
-    axios,
-  }))
+  const piniaOrm = createORM({
+    plugins: [
+      createPiniaOrmAxios({
+        axios,
+      }),
+    ],
+  })
   pinia.use(piniaOrm)
   app.use(pinia)
   setActivePinia(pinia)

--- a/packages/pinia-orm/src/store/Store.ts
+++ b/packages/pinia-orm/src/store/Store.ts
@@ -20,6 +20,7 @@ export interface CacheConfigOptions {
 export interface InstallOptions {
   model?: ModelConfigOptions
   cache?: CacheConfigOptions | boolean
+  plugins?: PiniaOrmPlugin[]
 }
 
 export interface FilledInstallOptions {
@@ -37,13 +38,9 @@ export interface CreatePiniaOrm {
 export function createORM (options?: InstallOptions): PiniaPlugin {
   config.model = { ...CONFIG_DEFAULTS.model, ...options?.model }
   config.cache = options?.cache === false ? false : { ...CONFIG_DEFAULTS.cache, ...(options?.cache !== true && options?.cache) }
-  const orm = () => {
-    function use (plugin: PiniaOrmPlugin) {
-      plugins.push(plugin)
-    }
-    return {
-      use,
-    }
+
+  if (options?.plugins) {
+    options.plugins.forEach(plugin => plugins.push(plugin))
   }
-  return orm
+  return () => {}
 }

--- a/packages/pinia-orm/tests/helpers.ts
+++ b/packages/pinia-orm/tests/helpers.ts
@@ -18,10 +18,7 @@ interface Entities {
 export function createPiniaORM (options?: InstallOptions, plugins?: PiniaOrmPlugin[]) {
   const app = createApp({})
   const pinia = createPinia()
-  const piniaOrm = createORM(options)
-  if (plugins) {
-    plugins.forEach(plugin => piniaOrm().use(plugin))
-  }
+  const piniaOrm = createORM({ ...options, plugins })
   pinia.use(piniaOrm)
   app.use(pinia)
   setActivePinia(pinia)

--- a/playgrounds/nuxt3/orm.ts
+++ b/playgrounds/nuxt3/orm.ts
@@ -1,0 +1,18 @@
+import { createPinia } from 'pinia';
+import { createORM } from 'pinia-orm';
+import { createPiniaOrmAxios } from '@pinia-orm/axios';
+import axios from 'axios';
+
+export default {
+  setup() {
+    const pinia = createPinia();
+    const piniaOrm = createORM({
+      plugins: [
+        createPiniaOrmAxios({
+          axios,
+        })
+      ]
+    });
+    pinia.use(piniaOrm);
+  },
+};

--- a/playgrounds/nuxt3/package.json
+++ b/playgrounds/nuxt3/package.json
@@ -8,13 +8,15 @@
     "start": "node .output/server/index.mjs"
   },
   "devDependencies": {
-    "@pinia-orm/nuxt": "^1.7.0",
+    "@pinia-orm/axios": "workspace:*",
+    "@pinia-orm/nuxt": "workspace:*",
     "@pinia/nuxt": "^0.5.1",
     "nuxt": "^3.11.2",
     "pinia": "^2.1.7",
     "pinia-orm": "workspace:*"
   },
   "dependencies": {
+    "axios": "^1.7.2",
     "nanoid": "^4.0.0",
     "uuid": "^8.3.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,6 +385,9 @@ importers:
 
   playgrounds/nuxt3:
     dependencies:
+      axios:
+        specifier: ^1.7.2
+        version: 1.7.2
       nanoid:
         specifier: ^4.0.0
         version: 4.0.2
@@ -392,9 +395,12 @@ importers:
         specifier: ^8.3.2
         version: 8.3.2
     devDependencies:
+      '@pinia-orm/axios':
+        specifier: workspace:*
+        version: link:../../packages/axios
       '@pinia-orm/nuxt':
-        specifier: ^1.7.0
-        version: 1.7.0(@pinia/nuxt@0.5.1(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(magicast@0.3.4)(rollup@4.14.0)(typescript@5.5.3)(vue@3.4.31(typescript@5.5.3)))(magicast@0.3.4)(pinia@2.1.7(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(typescript@5.5.3)(vue@3.4.31(typescript@5.5.3)))(rollup@4.14.0)
+        specifier: workspace:*
+        version: link:../../packages/nuxt
       '@pinia/nuxt':
         specifier: ^0.5.1
         version: 0.5.1(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(magicast@0.3.4)(rollup@4.14.0)(typescript@5.5.3)(vue@3.4.31(typescript@5.5.3))
@@ -13996,17 +14002,6 @@ snapshots:
       - rollup
       - supports-color
 
-  '@pinia-orm/nuxt@1.7.0(@pinia/nuxt@0.5.1(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(magicast@0.3.4)(rollup@4.14.0)(typescript@5.5.3)(vue@3.4.31(typescript@5.5.3)))(magicast@0.3.4)(pinia@2.1.7(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(typescript@5.5.3)(vue@3.4.31(typescript@5.5.3)))(rollup@4.14.0)':
-    dependencies:
-      '@nuxt/kit': 3.12.3(magicast@0.3.4)(rollup@4.14.0)
-      '@pinia/nuxt': 0.5.1(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(magicast@0.3.4)(rollup@4.14.0)(typescript@5.5.3)(vue@3.4.31(typescript@5.5.3))
-      pinia-orm: 1.7.2(pinia@2.1.7(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(typescript@5.5.3)(vue@3.4.31(typescript@5.5.3)))
-    transitivePeerDependencies:
-      - magicast
-      - pinia
-      - rollup
-      - supports-color
-
   '@pinia/nuxt@0.2.1(@vue/composition-api@1.7.2(vue@2.7.16))(pinia@2.1.7(@vue/composition-api@1.7.2(vue@2.7.16))(typescript@4.2.4)(vue@2.7.16))(vue@2.7.16)':
     dependencies:
       pinia: 2.1.7(@vue/composition-api@1.7.2(vue@2.7.16))(typescript@4.2.4)(vue@2.7.16)
@@ -20929,11 +20924,6 @@ snapshots:
     dependencies:
       '@pinia-orm/normalizr': 1.9.1
       pinia: 2.1.7(@vue/composition-api@1.7.2(vue@2.7.16))(typescript@4.2.4)(vue@2.7.16)
-
-  pinia-orm@1.7.2(pinia@2.1.7(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(typescript@5.5.3)(vue@3.4.31(typescript@5.5.3))):
-    dependencies:
-      '@pinia-orm/normalizr': 1.9.1
-      pinia: 2.1.7(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(typescript@5.5.3)(vue@3.4.31(typescript@5.5.3))
 
   pinia@2.1.7(@vue/composition-api@1.7.2(vue@2.7.16))(typescript@4.2.4)(vue@2.7.16):
     dependencies:


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1901, resolves #1859, resolves #1694, resolves #1687

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This is a breaking change which is necessary to keep aligned with pinia plugin types.
Instead of using `createORM().use(plugin)` you must use `createORM({ plugins: [plugin] })`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Pinia ORM!
----------------------------------------------------------------------->

BREAKING-CHANGE: Removed `createORM().use(PUGIN)`. Use `createORM({plugins: [PLUGIN] })` instead.
