### PR TITLE
fix(pinia-orm): Model original data is overwritten by different namspace models with same ID

### DIFF
--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -123,7 +123,7 @@ export class Model {
   /**
    * Original model data.
    */
-  protected static original: Record<string, any> = {}
+  protected static original: Record<string, Record<string, Element>> = {}
 
   /**
    * The schema for the model. It contains the result of the `fields`
@@ -825,7 +825,9 @@ export class Model {
       this[key as keyof this] = this[key as keyof this] ?? keyValue
     }
 
-    operation === 'set' && (this.$self().original[this.$getKey(this, true) as string] = this.$getAttributes())
+    operation === 'set' && (
+      (this.$self().original[this.$modelEntity()] ??= {})[this.$getKey(this, true) as string] = this.$getAttributes()
+    )
 
     modelConfig.withMeta && operation === 'set' && this.$fillMeta(options.action)
 
@@ -1003,7 +1005,7 @@ export class Model {
    * Get the original values of the model instance
    */
   $getOriginal (): Element {
-    return this.$self().original[this.$getKey(this, true) as string]
+    return (this.$self().original[this.$modelEntity()] ??= {})[this.$getKey(this, true) as string]
   }
 
   /**

--- a/packages/pinia-orm/tests/unit/model/Model_Isolation.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Isolation.spec.ts
@@ -54,12 +54,12 @@ describe('unit/model/ModelIsolation', () => {
   it('handles multiple instances of different models with same ids', () => {
     const users = [
       new User({ id: 1, name: 'John' }),
-      new User({ id: 2, name: 'Jane' })
+      new User({ id: 2, name: 'Jane' }),
     ]
-    
+
     const posts = [
       new Post({ id: 1, title: 'First' }),
-      new Post({ id: 2, title: 'Second' })
+      new Post({ id: 2, title: 'Second' }),
     ]
 
     users.forEach(u => u.name = `Updated ${u.name}`)

--- a/packages/pinia-orm/tests/unit/model/Model_Isolation.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Isolation.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { Model } from '../../../src'
+import { Attr } from '../../../src/decorators'
+
+describe('unit/model/ModelIsolation', () => {
+  class User extends Model {
+    static entity = 'users'
+    @Attr() declare id: number
+    @Attr() declare name: string
+  }
+
+  class Post extends Model {
+    static entity = 'posts'
+    @Attr() declare id: number
+    @Attr() declare title: string
+  }
+
+  it('maintains separate original states for different model types with same id', () => {
+    const user = new User({ id: 1, name: 'John' })
+    const post = new Post({ id: 1, title: 'Hello' })
+
+    expect(user.$getOriginal()).toEqual({ id: 1, name: 'John' })
+    expect(post.$getOriginal()).toEqual({ id: 1, title: 'Hello' })
+  })
+
+  it('tracks changes independently for different model types', () => {
+    const user = new User({ id: 1, name: 'John' })
+    const post = new Post({ id: 1, title: 'Hello' })
+
+    user.name = 'Jane'
+    post.title = 'Updated'
+
+    expect(user.$isDirty()).toBeTruthy()
+    expect(post.$isDirty()).toBeTruthy()
+    expect(user.$getOriginal()).toEqual({ id: 1, name: 'John' })
+    expect(post.$getOriginal()).toEqual({ id: 1, title: 'Hello' })
+  })
+
+  it('refreshes to correct original state for each model type', () => {
+    const user = new User({ id: 1, name: 'John' })
+    const post = new Post({ id: 1, title: 'Hello' })
+
+    user.name = 'Jane'
+    post.title = 'Updated'
+
+    user.$refresh()
+    expect(user.name).toBe('John')
+    expect(post.title).toBe('Updated')
+
+    post.$refresh()
+    expect(post.title).toBe('Hello')
+  })
+
+  it('handles multiple instances of different models with same ids', () => {
+    const users = [
+      new User({ id: 1, name: 'John' }),
+      new User({ id: 2, name: 'Jane' })
+    ]
+    
+    const posts = [
+      new Post({ id: 1, title: 'First' }),
+      new Post({ id: 2, title: 'Second' })
+    ]
+
+    users.forEach(u => u.name = `Updated ${u.name}`)
+    posts.forEach(p => p.title = `Updated ${p.title}`)
+
+    expect(users[0].$getOriginal()).toEqual({ id: 1, name: 'John' })
+    expect(users[1].$getOriginal()).toEqual({ id: 2, name: 'Jane' })
+    expect(posts[0].$getOriginal()).toEqual({ id: 1, title: 'First' })
+    expect(posts[1].$getOriginal()).toEqual({ id: 2, title: 'Second' })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1953

### 📚 Description


The `original` static property in the Model class stores original states using only the model's ID as the key, causing different model types to overwrite each other's original states when they share the same ID.

This PR is separating/namespacing the original states by model entity
