### PR TITLE
fix(pinia-orm): UID Decorator: Setting Custom Alphabet Results in "undefined" Instead of Characters in UIDs

### DIFF
--- a/packages/pinia-orm/src/support/Utils.ts
+++ b/packages/pinia-orm/src/support/Utils.ts
@@ -227,7 +227,7 @@ export function generateId (size: number, alphabet: string) {
   let i = size
   while (i--) {
     // `| 0` is more compact and faster than `Math.floor()`.
-    id += alphabet[(Math.random() * 64) | 0]
+    id += alphabet[(Math.random() * alphabet.length) | 0]
   }
   return id
 }

--- a/packages/pinia-orm/tests/unit/model/Model_Attrs_UID.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Attrs_UID.spec.ts
@@ -18,6 +18,18 @@ describe('unit/model/Model_Attrs_UID', () => {
     expect(new User().id).toBe('uid1')
   })
 
+  it('creates a random Uid with correct alphabet usage', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Uid({ alphabet: '123456789', size: 5 })
+      id!: string
+    }
+
+    expect(new User().id.length).toBe(5)
+    expect(typeof Number(new User().id)).toBe('number')
+  })
+
   it('creates a random Uid with options', () => {
     class User extends Model {
       static entity = 'users'


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1928

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Pinia ORM!
----------------------------------------------------------------------->
