### PR TITLE
fix(pinia-orm): Ordering sometimes wrong with Query.orderBy and UseCollect.sortBy

### DIFF
--- a/packages/pinia-orm/src/support/Utils.ts
+++ b/packages/pinia-orm/src/support/Utils.ts
@@ -83,7 +83,7 @@ export function orderBy<T extends Element> (
   const result = collection.map<SortableArray<T>>((value) => {
     const criteria = iteratees.map((iteratee) => {
       if (typeof iteratee === 'function') { return iteratee(value) }
-      if (!iteratee.includes('.') && !isDate(value[iteratee])) { return value[iteratee]}
+      if (!iteratee.includes('.') && !isDate(value[iteratee])) { return value[iteratee] }
       const newValue = getValue(value, iteratee, false)
       return isDate(newValue) ? new Date(newValue).getTime() : newValue
     })

--- a/packages/pinia-orm/src/support/Utils.ts
+++ b/packages/pinia-orm/src/support/Utils.ts
@@ -83,6 +83,7 @@ export function orderBy<T extends Element> (
   const result = collection.map<SortableArray<T>>((value) => {
     const criteria = iteratees.map((iteratee) => {
       if (typeof iteratee === 'function') { return iteratee(value) }
+      if (!iteratee.includes('.') && !isDate(value[iteratee])) { return value[iteratee]}
       const newValue = getValue(value, iteratee, false)
       return isDate(newValue) ? new Date(newValue).getTime() : newValue
     })


### PR DESCRIPTION


### 🔗 Linked issue

resolves #1858 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This is a maybe fix....still needs a unit test to find the reason for breaking....<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Pinia ORM!
----------------------------------------------------------------------->
