### PR TITLE
docs(axios): fix broken links to configuration page

### DIFF
--- a/docs/content/3.plugins/2.axios/1.guide/2.usage.md
+++ b/docs/content/3.plugins/2.axios/1.guide/2.usage.md
@@ -10,7 +10,7 @@ await useAxiosRepo(User).api().get('https://example.com/api/users')
 
 ## Performing Requests
 
-Pinia ORM Axios supports the most commonly used [axios request methods](https://github.com/axios/axios#request-method-aliases). These methods accept the same argument signature as their axios counterparts with the exception that the config can be expanded with additional plugin [options](configurations).
+Pinia ORM Axios supports the most commonly used [axios request methods](https://github.com/axios/axios#request-method-aliases). These methods accept the same argument signature as their axios counterparts with the exception that the config can be expanded with additional plugin [options](configuration).
 
 ### Supported Methods
 
@@ -29,7 +29,7 @@ Arguments given are passed on to the corresponding axios request method.
 
 - `url` is the server URL that will be used for the request.
 - `data` is the data to be sent as the request body (where applicable).
-- `config` is the plugin [config options](configurations) and also any valid [axios request config](https://github.com/axios/axios#request-config) options.
+- `config` is the plugin [config options](configuration) and also any valid [axios request config](https://github.com/axios/axios#request-config) options.
 
 ### Request Configuration
 
@@ -46,11 +46,11 @@ useAxiosRepo(User).api().get('/api/users', {
 
 The [`baseURL`](https://github.com/axios/axios#request-config) is an axios request option which will be prepended to the request URL (unless the URL is absolute).
 
-The [`dataKey`](configurations.md#datakey) is a plugin option which informs the plugin of the resource key your elements may be nested under in the response body.
+The [`dataKey`](configuration.md#datakey) is a plugin option which informs the plugin of the resource key your elements may be nested under in the response body.
 
 > Please refer to the list of [supported request methods](#supported-methods) above to determine where the `config` argument can be given in the corresponding request method.
 
-**See also**: [Configurations](configurations)
+**See also**: [Configurations](configuration)
 
 ### Persisting Response Data
 
@@ -121,7 +121,7 @@ useAxiosRepo(User).api().delete('/api/users/1', {
 })
 ```
 
-**See also**: [Configurations - delete](configurations.md#delete)
+**See also**: [Configurations - delete](configuration.md#delete)
 
 ## Handling Responses
 
@@ -176,7 +176,7 @@ useAxiosRepo(User).api().get('/api/users', {
 })
 ```
 
-**See also**: [Configurations - dataTransformer](configurations.md#datatransformer)
+**See also**: [Configurations - dataTransformer](configuration.md#datatransformer)
 
 ### Deferring Persistence
 
@@ -217,6 +217,6 @@ result.isSaved // true
 
 **See also**:
 
-- [Configurations - save](configurations.md#save)
+- [Configurations - save](configuration.md#save)
 - [API Reference - Response - save()](../api/response.md#save)
 - [API Reference - Response - isSaved](../api/response.md#issaved)

--- a/docs/content/3.plugins/2.axios/2.api/3.response.md
+++ b/docs/content/3.plugins/2.axios/2.api/3.response.md
@@ -20,7 +20,7 @@ API requests return a Response object. This is responsible for carrying and hand
 
   The return value from the Pinia ORM persist method.
 
-  **See also**: [Configurations - save](../guide/configurations.md#save)
+  **See also**: [Configurations - save](../guide/configuration.md#save)
 
 ### `isSaved`
 


### PR DESCRIPTION
The axios usage guide and response API docs linked to `/plugins/axios/guide/configurations` which is a 404. The correct page is `/plugins/axios/guide/configuration`.

fixes #2017