### PR TITLE
fix(nuxt): resolve vue3 runtime plugin on Nuxt 4

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,4 +1,4 @@
-import { addImports, addPlugin, addTemplate, createResolver, defineNuxtModule, isNuxt3 } from '@nuxt/kit'
+import { addImports, addPlugin, addTemplate, createResolver, defineNuxtModule, isNuxt2 } from '@nuxt/kit'
 import type { InstallOptions } from 'pinia-orm'
 import { CONFIG_DEFAULTS } from 'pinia-orm'
 
@@ -63,7 +63,7 @@ export const ormOptions = ${JSON.stringify(options, null, 2)}
       },
     })
 
-    addPlugin(resolver.resolve('./runtime/plugin.vue' + (isNuxt3() ? '3' : '2')), {
+    addPlugin(resolver.resolve('./runtime/plugin.vue' + (isNuxt2(nuxt) ? '2' : '3')), {
       append: true,
     })
 


### PR DESCRIPTION
The module resolved its runtime plugin via `isNuxt3() ? '3' : '2'`, so any Nuxt major other than 3 — including Nuxt 4 — fell back to the Nuxt 2 plugin and the app broke.

This inverts the check to `isNuxt2(nuxt) ? '2' : '3'`: only Nuxt 2 gets the vue2 plugin, every newer major (3, 4, …) resolves the vue3 plugin.

`isNuxtMajorVersion()` is not available in the @nuxt/kit version pinned on 1.x (3.12.3, added in 3.13), so the still-supported `isNuxt2()` is used instead. On `main` (v2) the module no longer has the vue2/vue3 split, so this only affects the 1.x line.

Verified with a local `nuxt-module-build build`.

fixes #2019