### PR TITLE
fix(axios): apply global plugin config on first repository use

### DIFF
--- a/packages/axios/src/api/Request.ts
+++ b/packages/axios/src/api/Request.ts
@@ -34,14 +34,14 @@ export class Request {
    * Get the axios client.
    */
   get axios (): AxiosInstance {
-    this.repository.axios = this.repository.axios ?? this.repository.config.axiosApi.axios
-    if (!this.repository.axios) {
+    const axios = this.repository.axios
+    if (!axios) {
       throw new Error(
         '[Pinia ORM Axios] The axios instance is not registered. Please register the axios instance to the repository.',
       )
     }
 
-    return this.repository.axios
+    return axios
   }
 
   /**

--- a/packages/axios/src/repository/AxiosRepository.ts
+++ b/packages/axios/src/repository/AxiosRepository.ts
@@ -1,20 +1,32 @@
-import type { Database, Model } from 'pinia-orm'
-import type { Pinia } from 'pinia'
-import { Repository, config } from 'pinia-orm'
+import type { Model } from 'pinia-orm'
+import { Repository } from 'pinia-orm'
 import type { AxiosInstance } from 'axios'
 import { useAxiosApi } from '../index'
 import type { Config, GlobalConfig } from '../types/config'
 
 export class AxiosRepository<M extends Model = Model> extends Repository<M> {
-  axios: AxiosInstance
-  globalApiConfig: GlobalConfig
-  apiConfig: Config
+  apiConfig: Config = {}
 
-  constructor (database: Database, pinia?: Pinia) {
-    super(database, pinia)
-    this.axios = config?.axiosApi?.axios || null
-    this.globalApiConfig = config?.axiosApi || {}
-    this.apiConfig = {}
+  protected axiosInstance: AxiosInstance | null = null
+
+  /**
+   * The axios instance from the plugin config, unless an instance was set
+   * explicitly via `setAxios`. The plugin config is resolved lazily because
+   * plugins are registered after the repository has been constructed.
+   */
+  get axios (): AxiosInstance | null {
+    return this.axiosInstance ?? this.globalApiConfig.axios ?? null
+  }
+
+  set axios (axios: AxiosInstance | null) {
+    this.axiosInstance = axios
+  }
+
+  /**
+   * The global plugin config passed to `createPiniaOrmAxios`.
+   */
+  get globalApiConfig (): GlobalConfig {
+    return this.config.axiosApi ?? {}
   }
 
   api () {

--- a/packages/axios/test/feature/Request_GlobalConfig.spec.ts
+++ b/packages/axios/test/feature/Request_GlobalConfig.spec.ts
@@ -1,0 +1,66 @@
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { createPinia, setActivePinia } from 'pinia'
+import { createApp } from 'vue'
+import { Model, config, createORM } from 'pinia-orm'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { assertState } from '../helpers'
+import { createPiniaOrmAxios, useAxiosRepo } from '../../src'
+
+describe('Feature - Request - Global Config', () => {
+  let mock: MockAdapter
+
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        name: this.attr(''),
+      }
+    }
+  }
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios)
+  })
+  afterEach(() => {
+    mock.reset()
+  })
+
+  it('applies global plugin options like baseURL and dataKey on first repository use', async () => {
+    // Simulate a freshly booted app where no repository has been used yet,
+    // so the axios plugin has not been applied to the global config.
+    delete config.axiosApi
+
+    const app = createApp({})
+    const pinia = createPinia()
+    pinia.use(createORM({
+      plugins: [
+        createPiniaOrmAxios({
+          axios,
+          baseURL: 'https://example.com/api',
+          dataKey: 'data',
+        }),
+      ],
+    }))
+    app.use(pinia)
+    setActivePinia(pinia)
+
+    mock.onGet('https://example.com/api/users').reply(200, {
+      data: [{ id: 1, name: 'John Doe' }],
+    })
+
+    const userStore = useAxiosRepo(User)
+
+    await userStore.api().get('/users')
+
+    expect(mock.history.get[0].baseURL).toBe('https://example.com/api')
+
+    assertState({
+      users: {
+        1: { id: 1, name: 'John Doe' },
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Bug

`AxiosRepository` captured `config.axiosApi` (axios instance + global plugin config) **in its constructor** — but ORM plugins are registered via `registerPlugins()` *after* the repository is constructed. On the first `useAxiosRepo()` call of an app the repository therefore saw an empty `globalApiConfig`, and global options like `baseURL` and `dataKey` were silently dropped from every request built by that repository (#1987).

The axios instance itself only appeared to work because `Request#axios` had a fallback to `repository.config.axiosApi.axios`.

## Fix

`axios` and `globalApiConfig` are now lazy getters that resolve from `this.config.axiosApi` — the plugin-merged config the repository receives via `setConfig()` during plugin registration. `setAxios()` still overrides the instance. The `Request#axios` workaround fallback is gone.

## Tests

New regression test that simulates a freshly booted app (no prior repository use) with `baseURL` + `dataKey` in the global plugin config — fails with 404 before the fix, passes after. Full axios suite green (23 tests).

fixes #1987
