### PR TITLE
fix(pinia-orm): apply casts before field type validation on save

### DIFF
--- a/packages/pinia-orm/src/model/Model.ts
+++ b/packages/pinia-orm/src/model/Model.ts
@@ -826,11 +826,18 @@ export class Model {
 
       if (cast && operation === 'get') { value = cast.get(value) }
 
+      // Apply the cast before the field is filled so the type check
+      // validates the casted value instead of the raw input.
+      if (cast && operation === 'set' && value !== undefined) {
+        value = options.action === 'update' ? cast.get(value) : cast.set(value)
+      }
+
       let keyValue = this.$fillField(key, attr, value)
 
       if (mutator && typeof mutator !== 'function' && operation === 'set' && mutator.set) { keyValue = mutator.set(keyValue) }
 
-      if (cast && operation === 'set') {
+      // Values filled by the attribute default still need to pass the cast.
+      if (cast && operation === 'set' && value === undefined) {
         keyValue = options.action === 'update' ? cast.get(keyValue) : cast.set(keyValue)
       }
 

--- a/packages/pinia-orm/tests/unit/model/Model_Casts_Number.spec.ts
+++ b/packages/pinia-orm/tests/unit/model/Model_Casts_Number.spec.ts
@@ -92,4 +92,34 @@ describe('unit/model/Model_Casts_Number', () => {
 
     expect(userRepo.find(1)?.count).toBe(444)
   })
+
+  it('should not warn about a wrong type when the cast converts the value on save', () => {
+    const warningSpy = vi.spyOn(console, 'warn')
+    warningSpy.mockClear()
+
+    class User extends Model {
+      static entity = 'users'
+
+      @Attr(0) id!: number
+
+      @Cast(() => NumberCast)
+      @Num(null)
+      count!: number | null
+    }
+
+    const userRepo = useRepo(User)
+    userRepo.save({
+      id: 1,
+      count: '10191',
+    })
+
+    assertState({
+      users: {
+        1: { id: 1, count: 10191 },
+      },
+    })
+
+    expect(userRepo.find(1)?.count).toBe(10191)
+    expect(warningSpy).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Bug

When saving, casts for the `set` operation were applied **after** `$fillField()`. The attribute type check therefore validated the raw input and logged spurious warnings like

```
[Pinia ORM] Field notes:organization_id - 10191 is not a number
```

even though the cast (e.g. `NumberCast`) converts the value immediately afterwards and the store ends up with the correct value (#2003).

## Fix

Apply the cast before the field is filled, so type validation sees the casted value. Values that fall back to the attribute default (input `undefined`) still pass through the cast after filling — unchanged behavior. Side effect worth noting: when a field has **both** a set-mutator and a cast, the mutator now receives the casted value (cast → mutate instead of mutate-after-cast) — this mirrors the get path (mutate → cast) symmetrically.

## Tests

New regression test: `@Cast(() => NumberCast) @Num(null)` field saved with a string value must not warn and must store the number. Fails before, passes after. Full suite green (402 tests).

fixes #2003