### PR TITLE
fix(pinia-orm): fall back to strong refs when WeakRef is unavailable

### DIFF
--- a/packages/pinia-orm/src/cache/WeakCache.ts
+++ b/packages/pinia-orm/src/cache/WeakCache.ts
@@ -1,8 +1,28 @@
+interface ValueRef<V extends object> {
+  deref(): V | undefined
+}
+
+/**
+ * Fallback for environments without WeakRef support (e.g. Cloudflare
+ * Workers). Values are held strongly instead of crashing.
+ */
+class StrongRef<V extends object> implements ValueRef<V> {
+  #value: V
+
+  constructor (value: V) {
+    this.#value = value
+  }
+
+  deref (): V {
+    return this.#value
+  }
+}
+
 export class WeakCache<K, V extends object> implements Map<K, V> {
   // @ts-expect-error dont know
   readonly [Symbol.toStringTag]: string
 
-  #map = new Map<K, WeakRef<V>>()
+  #map = new Map<K, ValueRef<V>>()
 
   has (key: K) {
     return !!(this.#map.has(key) && this.#map.get(key)?.deref())
@@ -25,7 +45,7 @@ export class WeakCache<K, V extends object> implements Map<K, V> {
   }
 
   set (key: K, value: V) {
-    this.#map.set(key, new WeakRef<V>(value))
+    this.#map.set(key, typeof WeakRef === 'undefined' ? new StrongRef<V>(value) : new WeakRef<V>(value))
     return this
   }
 

--- a/packages/pinia-orm/tests/unit/cache/Weakcache.spec.ts
+++ b/packages/pinia-orm/tests/unit/cache/Weakcache.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { WeakCache } from '../../../src/cache/WeakCache'
 
@@ -71,5 +71,18 @@ describe('unit/support/Weakcache', () => {
   it('can clear all', () => {
     cache.clear()
     expect(cache.size).toEqual(0)
+  })
+
+  it('falls back to strong references when WeakRef is not available', () => {
+    vi.stubGlobal('WeakRef', undefined)
+
+    const fallbackCache = new WeakCache()
+    fallbackCache.set('key1', data)
+
+    expect(fallbackCache.get('key1')).toEqual(data)
+    expect(fallbackCache.has('key1')).toBeTruthy()
+    expect([...fallbackCache.values()]).toEqual([data])
+
+    vi.unstubAllGlobals()
   })
 })


### PR DESCRIPTION
## Bug

The default query cache (`WeakCache`) constructs `WeakRef` instances on every `set()`. Environments without `WeakRef` support — notably Cloudflare Workers — throw `WeakRef is not defined` as soon as anything is cached, which breaks Nuxt SSR on that platform (#1949).

## Fix

`WeakCache#set()` now falls back to an internal `StrongRef` (same `deref()` shape) when `WeakRef` is not available. Degraded mode holds values strongly — acceptable for short-lived worker isolates, and far better than crashing. No behavior change where `WeakRef` exists.

## Tests

New test stubs `WeakRef` away (`vi.stubGlobal`) and verifies set/get/has/iteration still work. Full suite green.

fixes #1949