### PR TITLE
docs(axios): add Nuxt setup guide for the axios plugin

### DIFF
--- a/docs/content/3.plugins/2.axios/1.guide/1.setup.md
+++ b/docs/content/3.plugins/2.axios/1.guide/1.setup.md
@@ -57,4 +57,39 @@ or you use `pinaOrmPluginAxios`. It depends if you want to pass options on initi
   ```
 ::
 
+## Usage with Nuxt
+
+With Nuxt you register the plugin in a Nuxt plugin file, e.g. `plugins/pinia-orm-axios.ts`. The plugin has to be applied to the pinia instance after the `pinia` plugin has been set up:
+
+```ts
+import { defineNuxtPlugin, usePinia } from '#imports'
+import { createPiniaOrmAxios } from '@pinia-orm/axios'
+import axios from 'axios'
+import { setActivePinia } from 'pinia'
+import { createORM } from 'pinia-orm'
+
+export default defineNuxtPlugin({
+  name: 'pinia-orm-axios',
+  dependsOn: ['pinia'],
+  setup () {
+    const pinia = usePinia()
+
+    pinia.use(createORM({
+      plugins: [
+        createPiniaOrmAxios({
+          axios,
+          // baseURL: 'https://example.com/api',
+        }),
+      ],
+    }))
+
+    setActivePinia(pinia)
+  },
+})
+```
+
+::alert{type="info"}
+When you register `createORM` yourself in a plugin like this, you don't need the `@pinia-orm/nuxt` module — the plugin above replaces it.
+::
+
 


### PR DESCRIPTION
Adds a *Usage with Nuxt* section to the axios plugin setup page, based on the working setup from the issue discussion (Nuxt plugin with `dependsOn: ['pinia']`, `createORM` with the axios plugin, `setActivePinia`).

closes #1804