### PR TITLE
ci: fix release pr lookup in the changelog workflow

### DIFF
--- a/scripts/update-changelog.ts
+++ b/scripts/update-changelog.ts
@@ -38,8 +38,15 @@ async function main () {
     execSync(`git push -u origin v${newVersion}`)
   }
 
-  // Get the current PR for this release, if it exists
-  const [currentPR] = await $fetch(`https://api.github.com/repos/CodeDredd/pinia-orm/pulls?head=v${newVersion}`)
+  // Get the current PR for this release, if it exists. The `head` filter
+  // needs the `owner:` prefix — without it GitHub ignores the filter and
+  // returns the newest open PR, whose body would then be overwritten.
+  const [currentPR] = await $fetch(`https://api.github.com/repos/CodeDredd/pinia-orm/pulls?head=CodeDredd:v${newVersion}&state=open`)
+
+  if (currentPR && currentPR.head?.ref !== `v${newVersion}`) {
+    consola.error(`Found PR #${currentPR.number} but its head is not v${newVersion}. Aborting to avoid overwriting an unrelated PR.`)
+    process.exit(1)
+  }
   const contributors = await getContributors()
 
   const latestTag = await getLatestTag()


### PR DESCRIPTION
The changelog workflow looked up the release PR via `pulls?head=v2.0.0` — but GitHub's `head` filter requires the `owner:` prefix. Without it the filter is **ignored**, the API returns the newest open PR, and the workflow appended the v2.0.0 release notes to that PR's body (this happened to several feature PRs; bodies are being cleaned up).

- `head=CodeDredd:v${newVersion}&state=open`
- safety guard: abort if the found PR's head ref isn't the release branch

Together with deleting the stale `v2.0.0` branch (created from an old main state), the next main push will regenerate the release branch + draft release PR from the current state.