### PR TITLE
chore(pinia-orm): raise index bundle size limit to 16.5 kB

### DIFF
--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -91,7 +91,7 @@
   "size-limit": [
     {
       "path": "dist/index.mjs",
-      "limit": "16 kB"
+      "limit": "16.5 kB"
     },
     {
       "path": "dist/decorators.mjs",


### PR DESCRIPTION
The main CI size job started failing after the 2.0.0 feature merges: `dist/index.mjs` is now 16.02 kB brotlied — 20 bytes over the 16 kB limit. Raising the limit to 16.5 kB to account for the six new features (whereLike, collator sorting, updateOrCreate/firstOrCreate, fresh hooks, recursive STI, per-entity mutator scoping). All other budgets unchanged and well below their limits.