### PR TITLE
feat(pinia-orm)!: require node >= 22 and support pinia 4

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm i -g --force corepack && corepack enable
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: npm i -g --force corepack && corepack enable
 
-      - name: Set node version to 20
+      - name: Set node version to 22
         uses: actions/setup-node@v4.0.2
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install pnpm
@@ -47,10 +47,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: npm i -g --force corepack && corepack enable
 
-      - name: Set node version to 20
+      - name: Set node version to 22
         uses: actions/setup-node@v4.0.2
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - run: pnpm i
@@ -73,10 +73,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: npm i -g --force corepack && corepack enable
 
-      - name: Set node version to 20
+      - name: Set node version to 22
         uses: actions/setup-node@v4.0.2
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - run: pnpm i
@@ -95,10 +95,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: npm i -g --force corepack && corepack enable
 
-      - name: Set node version to 20
+      - name: Set node version to 22
         uses: actions/setup-node@v4.0.2
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - run: pnpm i

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm i -g --force corepack && corepack enable
       - uses: actions/setup-node@v4.0.2
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - run: npm i -g --force corepack && corepack enable
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org/"
           cache: "pnpm"
 

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -54,8 +54,8 @@
   "license": "MIT",
   "peerDependencies": {
     "axios": ">=1.13.2",
-    "pinia-orm": ">=1.9.1 || >=2.0.0-alpha",
-    "pinia": ">=3.0.0"
+    "pinia": ">=3.0.0",
+    "pinia-orm": ">=1.9.1 || >=2.0.0-alpha"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^1.1.0",
@@ -64,7 +64,7 @@
     "axios": "^1.7.2",
     "axios-mock-adapter": "^2.0.0",
     "eslint": "^9.21.0",
-    "pinia": "^3.0.1",
+    "pinia": "^4.0.2",
     "pinia-orm": "workspace:*",
     "size-limit": "^11.1.4",
     "typescript": "^5.8.2",
@@ -77,5 +77,8 @@
       "path": "dist/index.mjs",
       "limit": "2 kB"
     }
-  ]
+  ],
+  "engines": {
+    "node": ">=22.12.0"
+  }
 }

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -68,5 +68,8 @@
       "path": "dist/index.mjs",
       "limit": "2 kB"
     }
-  ]
+  ],
+  "engines": {
+    "node": ">=22.12.0"
+  }
 }

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -67,5 +67,8 @@
   "bugs": {
     "url": "https://github.com/CodeDredd/pinia-orm/issues"
   },
-  "homepage": "https://github.com/CodeDredd/pinia-orm/tree/v2/packages/nuxt#readme"
+  "homepage": "https://github.com/CodeDredd/pinia-orm/tree/v2/packages/nuxt#readme",
+  "engines": {
+    "node": ">=22.12.0"
+  }
 }

--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^1.1.0",
-    "@pinia/testing": "^0.1.3",
+    "@pinia/testing": "^2.0.1",
     "@size-limit/preset-small-lib": "^11.1.4",
     "@types/node": "^22.10.5",
     "@types/prettier": "^3.0.0",
@@ -76,7 +76,7 @@
     "happy-dom": "^20.0.0",
     "mkdist": "^2.1.0",
     "nanoid": "^5.1.0",
-    "pinia": "^3.0.1",
+    "pinia": "^4.0.2",
     "prettier": "^3.3.2",
     "size-limit": "^11.1.4",
     "std-env": "^3.7.0",
@@ -116,5 +116,8 @@
   "bugs": {
     "url": "https://github.com/CodeDredd/pinia-orm/issues"
   },
-  "homepage": "https://github.com/CodeDredd/pinia-orm#readme"
+  "homepage": "https://github.com/CodeDredd/pinia-orm#readme",
+  "engines": {
+    "node": ">=22.12.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: ^9.21.0
         version: 9.21.0(jiti@2.6.1)
       pinia:
-        specifier: ^3.0.1
-        version: 3.0.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
+        specifier: ^4.0.2
+        version: 4.0.2(@vue/devtools-api@7.7.2)(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
       pinia-orm:
         specifier: workspace:*
         version: link:../pinia-orm
@@ -199,8 +199,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(@vue/compiler-sfc@3.5.13)(eslint@9.21.0(jiti@2.6.1))(typescript@5.8.2)
       '@pinia/testing':
-        specifier: ^0.1.3
-        version: 0.1.3(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.8.2)))(pinia@3.0.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+        specifier: ^2.0.1
+        version: 2.0.1(pinia@4.0.2(@vue/devtools-api@7.7.2)(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))
       '@size-limit/preset-small-lib':
         specifier: ^11.1.4
         version: 11.1.4(size-limit@11.1.4)
@@ -244,8 +244,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       pinia:
-        specifier: ^3.0.1
-        version: 3.0.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
+        specifier: ^4.0.2
+        version: 4.0.2(@vue/devtools-api@7.7.2)(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
       prettier:
         specifier: ^3.3.2
         version: 3.3.2
@@ -2419,10 +2419,10 @@ packages:
     peerDependencies:
       pinia: ^3.0.2
 
-  '@pinia/testing@0.1.3':
-    resolution: {integrity: sha512-D2Ds2s69kKFaRf2KCcP1NhNZEg5+we59aRyQalwRm7ygWfLM25nDH66267U3hNvRUOTx8ofL24GzodZkOmB5xw==}
+  '@pinia/testing@2.0.1':
+    resolution: {integrity: sha512-pQ4a4SCzdiLrhM4yv/TQG2ufNmktNlLZjjN6X/qMhXvZIiDN3L4L4WrChmcufX2LIarbl/ZPWOty1RB5KZIb2A==}
     peerDependencies:
-      pinia: '>=2.1.5'
+      pinia: '>=4.0.2'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -6029,6 +6029,9 @@ packages:
     resolution: {integrity: sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==}
     engines: {node: '>=14.16'}
 
+  nostics@1.2.0:
+    resolution: {integrity: sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==}
+
   npm-run-path@2.0.2:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
     engines: {node: '>=4'}
@@ -6360,6 +6363,16 @@ packages:
     peerDependencies:
       typescript: '>=4.4.4'
       vue: ^2.7.0 || ^3.5.11
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  pinia@4.0.2:
+    resolution: {integrity: sha512-yKVVA7bSj5oRZFp/Ab9wLlmyb5gPUYEiIm4ryiWTe/xe7PtkRdMVOp1X1ggvq0c6Uj7Q0Du1HnV2mtAwM0Ks1g==}
+    peerDependencies:
+      '@vue/devtools-api': ^8.1.5
+      typescript: '>=5.6.0'
+      vue: ^3.5.11
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -10236,13 +10249,10 @@ snapshots:
       - magicast
       - supports-color
 
-  '@pinia/testing@0.1.3(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.8.2)))(pinia@3.0.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))':
+  '@pinia/testing@2.0.1(pinia@4.0.2(@vue/devtools-api@7.7.2)(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)))':
     dependencies:
-      pinia: 3.0.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
+      nostics: 1.2.0
+      pinia: 4.0.2(@vue/devtools-api@7.7.2)(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -14738,6 +14748,8 @@ snapshots:
 
   normalize-url@8.0.1: {}
 
+  nostics@1.2.0: {}
+
   npm-run-path@2.0.2:
     dependencies:
       path-key: 2.0.1
@@ -15289,6 +15301,14 @@ snapshots:
   pinia@3.0.2(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)):
     dependencies:
       '@vue/devtools-api': 7.7.2
+      vue: 3.5.13(typescript@5.8.2)
+    optionalDependencies:
+      typescript: 5.8.2
+
+  pinia@4.0.2(@vue/devtools-api@7.7.2)(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2)):
+    dependencies:
+      '@vue/devtools-api': 7.7.2
+      nostics: 1.2.0
       vue: 3.5.13(typescript@5.8.2)
     optionalDependencies:
       typescript: 5.8.2
@@ -17387,12 +17407,6 @@ snapshots:
       vue: 3.4.31(typescript@5.5.3)
     optionalDependencies:
       '@vue/composition-api': 1.7.2(vue@3.4.31(typescript@5.5.3))
-
-  vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2)):
-    dependencies:
-      vue: 3.5.13(typescript@5.8.2)
-    optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@3.5.13(typescript@5.8.2))
 
   vue-demi@0.14.8(@vue/composition-api@1.7.2(vue@3.4.31(typescript@5.5.3)))(vue@3.4.31(typescript@5.5.3)):
     dependencies:


### PR DESCRIPTION
## Node >= 22 (breaking, for 2.0.0)

Decision: **Node >= 22.12** instead of 24 —

- Nuxt 4 already requires `^22.19 || ^24.11`, Vite requires `^20.19 || >=22.12` → 22 is the ecosystem anchor
- Node 22 is in LTS maintenance until April 2027; requiring 24 would cut off every current LTS user for no technical gain
- pinia itself pins no engines, so Nuxt is the relevant sync point

Changes: `engines.node >= 22.12` in all four packages, CI/changelog/release workflows bumped from Node 20 to 22 (.nvmrc already was 22).

## pinia 4

pinia 4.0.2 is out. Full pinia-orm + axios suites run green against it **without any code changes** (426 + 25 tests). Dev dependencies now use pinia 4 + @pinia/testing 2, so CI permanently tests against pinia 4; the peer dependency stays `>=3.0.0`, so users on pinia 3 keep working.

No Node-22-specific refactors included on purpose — nothing in the codebase currently pays for them (no legacy Buffer/URL/crypto usage); can be done as a follow-up if something comes up.
