### PR TITLE
fix(pinia-orm): declare vue as peer dependency

### DIFF
--- a/packages/pinia-orm/package.json
+++ b/packages/pinia-orm/package.json
@@ -54,7 +54,8 @@
     "test": "vitest --run"
   },
   "peerDependencies": {
-    "pinia": ">=3.0.0"
+    "pinia": ">=3.0.0",
+    "vue": ">=3.4.0"
   },
   "dependencies": {
     "@pinia-orm/normalizr": "workspace:*"
@@ -91,7 +92,7 @@
   "size-limit": [
     {
       "path": "dist/index.mjs",
-      "limit": "16.5 kB"
+      "limit": "12 kB"
     },
     {
       "path": "dist/decorators.mjs",


### PR DESCRIPTION
## Why the reported bundle size was inflated

The setup store support (#1905, `953826a9`) added `import { ref } from 'vue'` to `useDataStore` — **but vue was never declared as a peer dependency**. Consequences:

1. **size-limit** only auto-ignores peer dependencies, so it bundled vue's reactivity system into the measurement: reported **16.18 kB** brotli instead of the real **11.75 kB**. Real apps were never affected (vue is in every pinia app anyway and gets deduplicated).
2. Package managers couldn't validate/warn about the vue version pinia-orm actually requires.

## Fix

- `vue >= 3.4` declared as peer dependency (pinia already requires vue as peer, so nothing changes at install time)
- index size limit lowered from the recently-raised 16.5 kB back to **12 kB** — the measurement now reflects what users actually pay

Suite green (430 tests), size check green at 11.75/12 kB.

Related: #2051 tracks the structural size reductions (tree-shakeable relations).