### PR TITLE
docs: explain purpose and use case of load()

### DIFF
--- a/docs/content/2.api/3.query/load.md
+++ b/docs/content/2.api/3.query/load.md
@@ -5,6 +5,8 @@ description: 'Eager load relations on the model.'
 
 # `load()`
 
+Attaches relations to models that were **already retrieved** from the store. Use it when you fetched a collection without `with()` — e.g. because the relations weren't needed at that point, or the data comes from a cached query — and you want to add relations afterwards without re-running the whole query. This is the lazy-loading counterpart to eager loading with [`with()`](with).
+
 ## Usage
 
 ````ts


### PR DESCRIPTION
Adds the missing *why/when* context to the `load()` API page, as requested in #1753 — it's the lazy-loading counterpart to `with()` for collections that were already retrieved. The API docs got a lot of usage context in the meantime (migration guide, cookbook, updated query pages), so this closes the issue.

closes #1753