### PR TITLE
fix(nuxt): use a standalone tsconfig for the module build

### DIFF
--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -1,3 +1,12 @@
 {
-    "extends": "./playground/.nuxt/tsconfig.json"
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
The v2.0.0 release workflow failed in `release.sh`'s full build: `packages/nuxt/tsconfig.json` extended `./playground/.nuxt/tsconfig.json`, which only exists after `nuxi prepare` — not on a fresh CI checkout. CI never caught it because `build:ci` doesn't build the nuxt package.

The module now uses a small standalone tsconfig. Verified locally with the generated playground files removed: `nuxt-module-build build` green.